### PR TITLE
security: remove hardcoded test API keys

### DIFF
--- a/examples/test_mas.py
+++ b/examples/test_mas.py
@@ -13,7 +13,7 @@ Agents:
 - Analyzer: Uses Google Gemini to analyze and summarize
 
 Usage:
-    export KALIBR_API_KEY=test_key_12345
+    export KALIBR_API_KEY=your-kalibr-api-key
     export KALIBR_COLLECTOR_URL=http://localhost:8000/api/v1/traces
     export KALIBR_TENANT_ID=acme-prod
     export OPENAI_API_KEY=<your-key>

--- a/kalibr/cli/run.py
+++ b/kalibr/cli/run.py
@@ -57,7 +57,10 @@ def run(
 
     # Configure backend
     backend = backend_url or os.getenv("KALIBR_BACKEND_URL", "http://localhost:8001")
-    api_key = os.getenv("KALIBR_API_KEY", "test_key_12345")
+    api_key = os.getenv("KALIBR_API_KEY")
+    if not api_key:
+        console.print("[yellow]⚠️  KALIBR_API_KEY not set. Set it for trace authentication.[/yellow]")
+        api_key = ""
 
     # Generate runtime metadata
     runtime_id = str(uuid.uuid4())

--- a/kalibr/simple_tracer.py
+++ b/kalibr/simple_tracer.py
@@ -54,7 +54,10 @@ def send_event(payload: dict):
         return
 
     url = os.getenv("KALIBR_COLLECTOR_URL", "http://localhost:8001/api/ingest")
-    api_key = os.getenv("KALIBR_API_KEY", "test_key_12345")
+    api_key = os.getenv("KALIBR_API_KEY")
+    if not api_key:
+        print("[Kalibr SDK] ⚠️  KALIBR_API_KEY not set, traces will not be sent")
+        return
 
     format_pref = os.getenv("KALIBR_COLLECTOR_FORMAT", "ndjson").lower()
     use_json_envelope = format_pref == "json"


### PR DESCRIPTION
- Remove hardcoded 'test_key_12345' default from simple_tracer.py and cli/run.py - now requires explicit KALIBR_API_KEY env var
- Add proper warnings when API key is not set
- Update example documentation to use placeholder instead of test key

This prevents accidental use of test credentials in production.