### PR TITLE
Remove hardcoded tenant ID from tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See the [`examples/`](./examples) directory for complete examples:
 
 ```bash
 # Clone the repository
-git clone https://github.com/kalibr-systems/kalibr-sdk-python.git
+git clone https://github.com/kalibr-ai/kalibr-sdk-python.git
 cd kalibr-sdk-python
 
 # Install in development mode
@@ -164,5 +164,5 @@ MIT License - see [LICENSE](./LICENSE) for details.
 ## Links
 
 - [Documentation](https://docs.kalibr.systems)
-- [GitHub Issues](https://github.com/kalibr-systems/kalibr-sdk-python/issues)
+- [GitHub Issues](https://github.com/kalibr-ai/kalibr-sdk-python/issues)
 - [PyPI Package](https://pypi.org/project/kalibr/)

--- a/kalibr/simple_tracer.py
+++ b/kalibr/simple_tracer.py
@@ -123,7 +123,7 @@ def trace(
             parent_span_id = kwargs.pop("parent_span_id", None)  # None or base62 string
 
             # Load environment config
-            tenant_id = os.getenv("KALIBR_TENANT_ID", "emergent")
+            tenant_id = os.getenv("KALIBR_TENANT_ID", "default")
             workflow_id = os.getenv("KALIBR_WORKFLOW_ID", "multi_agent_demo")
             sandbox_id = os.getenv("SANDBOX_ID", "vercel_vm_001")
             runtime_env = os.getenv("RUNTIME_ENV", "vercel_vm")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,10 @@ dev = [
 kalibr = "kalibr.cli.main:app"
 
 [project.urls]
-Homepage = "https://github.com/kalibr-systems/kalibr-sdk-python"
+Homepage = "https://github.com/kalibr-ai/kalibr-sdk-python"
 Documentation = "https://docs.kalibr.systems"
-Repository = "https://github.com/kalibr-systems/kalibr-sdk-python"
-Issues = "https://github.com/kalibr-systems/kalibr-sdk-python/issues"
+Repository = "https://github.com/kalibr-ai/kalibr-sdk-python"
+Issues = "https://github.com/kalibr-ai/kalibr-sdk-python/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- Removes hardcoded customer tenant ID ("emergent" → "default")
- Standardizes GitHub org from kalibr-systems to kalibr-ai
