### PR TITLE
Standardize endpoint defaults to api.kalibr.systems

### DIFF
--- a/kalibr/cli/capsule_cmd.py
+++ b/kalibr/cli/capsule_cmd.py
@@ -23,7 +23,7 @@ def capsule(
         None,
         "--api-url",
         "-u",
-        help="Kalibr API base URL (default: from env KALIBR_API_URL or http://localhost:8001)",
+        help="Kalibr API base URL (default: from env KALIBR_API_URL or https://api.kalibr.systems)",
         envvar="KALIBR_API_URL",
     ),
     output: Optional[Path] = typer.Option(
@@ -66,7 +66,7 @@ def capsule(
         kalibr capsule abc-123-def -u https://api.kalibr.io
     """
     # Determine API base URL
-    base_url = api_url or "http://localhost:8001"
+    base_url = api_url or "https://api.kalibr.systems"
     base_url = base_url.rstrip("/")
 
     # Build endpoint URL

--- a/kalibr/cli/run.py
+++ b/kalibr/cli/run.py
@@ -56,7 +56,7 @@ def run(
         raise typer.Exit(1)
 
     # Configure backend
-    backend = backend_url or os.getenv("KALIBR_BACKEND_URL", "http://localhost:8001")
+    backend = backend_url or os.getenv("KALIBR_BACKEND_URL", "https://api.kalibr.systems")
     api_key = os.getenv("KALIBR_API_KEY")
     if not api_key:
         console.print("[yellow]⚠️  KALIBR_API_KEY not set. Set it for trace authentication.[/yellow]")

--- a/kalibr/client.py
+++ b/kalibr/client.py
@@ -70,7 +70,7 @@ class KalibrClient:
 
         self.api_key = api_key or env_config.get("auth_token", "")
         self.endpoint = endpoint or env_config.get(
-            "api_endpoint", "http://localhost:8001/api/v1/traces"
+            "api_endpoint", "https://api.kalibr.systems/api/v1/traces"
         )
         self.tenant_id = tenant_id or env_config.get("tenant_id", "default")
         self.environment = environment or env_config.get("environment", "prod")

--- a/kalibr/middleware/auto_tracer.py
+++ b/kalibr/middleware/auto_tracer.py
@@ -54,7 +54,7 @@ class AutoTracerMiddleware(BaseHTTPMiddleware):
 
         # Collector config
         self.collector_url = collector_url or os.getenv(
-            "KALIBR_COLLECTOR_URL", "http://localhost:8001/api/ingest"
+            "KALIBR_COLLECTOR_URL", "https://api.kalibr.systems/api/ingest"
         )
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")

--- a/kalibr/simple_tracer.py
+++ b/kalibr/simple_tracer.py
@@ -53,7 +53,7 @@ def send_event(payload: dict):
         print("[Kalibr SDK] ❌ requests library not available")
         return
 
-    url = os.getenv("KALIBR_COLLECTOR_URL", "http://localhost:8001/api/ingest")
+    url = os.getenv("KALIBR_COLLECTOR_URL", "https://api.kalibr.systems/api/ingest")
     api_key = os.getenv("KALIBR_API_KEY")
     if not api_key:
         print("[Kalibr SDK] ⚠️  KALIBR_API_KEY not set, traces will not be sent")

--- a/kalibr/utils.py
+++ b/kalibr/utils.py
@@ -38,8 +38,8 @@ def load_config_from_env() -> Dict[str, str]:
         "workflow_id": os.getenv("KALIBR_WORKFLOW_ID", "default-workflow"),
         "sandbox_id": os.getenv("SANDBOX_ID", "local"),
         "runtime_env": os.getenv("RUNTIME_ENV", "local"),
-        "api_endpoint": os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces"),
-        "collector_url": os.getenv("KALIBR_COLLECTOR_URL", "http://localhost:8080/api/ingest"),
+        "api_endpoint": os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces"),
+        "collector_url": os.getenv("KALIBR_COLLECTOR_URL", "https://api.kalibr.systems/api/ingest"),
     }
     return config
 

--- a/kalibr_crewai/callbacks.py
+++ b/kalibr_crewai/callbacks.py
@@ -225,7 +225,7 @@ class KalibrAgentCallback:
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.endpoint = endpoint or os.getenv(
             "KALIBR_ENDPOINT",
-            os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces")
+            os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces")
         )
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
         self.environment = environment or os.getenv("KALIBR_ENVIRONMENT", "prod")
@@ -403,7 +403,7 @@ class KalibrTaskCallback:
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.endpoint = endpoint or os.getenv(
             "KALIBR_ENDPOINT",
-            os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces")
+            os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces")
         )
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
         self.environment = environment or os.getenv("KALIBR_ENVIRONMENT", "prod")

--- a/kalibr_crewai/instrumentor.py
+++ b/kalibr_crewai/instrumentor.py
@@ -66,7 +66,7 @@ class KalibrCrewAIInstrumentor:
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.endpoint = endpoint or os.getenv(
             "KALIBR_ENDPOINT",
-            os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces")
+            os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces")
         )
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
         self.environment = environment or os.getenv("KALIBR_ENVIRONMENT", "prod")

--- a/kalibr_langchain/async_callback.py
+++ b/kalibr_langchain/async_callback.py
@@ -65,7 +65,7 @@ class AsyncKalibrCallbackHandler(AsyncCallbackHandler):
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.endpoint = endpoint or os.getenv(
             "KALIBR_ENDPOINT",
-            os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces")
+            os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces")
         )
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
         self.environment = environment or os.getenv("KALIBR_ENVIRONMENT", "prod")

--- a/kalibr_langchain/callback.py
+++ b/kalibr_langchain/callback.py
@@ -202,7 +202,7 @@ class KalibrCallbackHandler(BaseCallbackHandler):
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.endpoint = endpoint or os.getenv(
             "KALIBR_ENDPOINT",
-            os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces")
+            os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces")
         )
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
         self.environment = environment or os.getenv("KALIBR_ENVIRONMENT", "prod")

--- a/kalibr_openai_agents/processor.py
+++ b/kalibr_openai_agents/processor.py
@@ -206,7 +206,7 @@ class KalibrTracingProcessor:
         self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
         self.endpoint = endpoint or os.getenv(
             "KALIBR_ENDPOINT",
-            os.getenv("KALIBR_API_ENDPOINT", "http://localhost:8001/api/v1/traces")
+            os.getenv("KALIBR_API_ENDPOINT", "https://api.kalibr.systems/api/v1/traces")
         )
         self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
         self.environment = environment or os.getenv("KALIBR_ENVIRONMENT", "prod")


### PR DESCRIPTION
Update all default endpoints from localhost to the hosted Kalibr backend at api.kalibr.systems for zero-friction onboarding.

Users can still override via environment variables:
- KALIBR_API_ENDPOINT
- KALIBR_COLLECTOR_URL
- KALIBR_BACKEND_URL
- KALIBR_API_URL