### PR TITLE
Add outcome loop helper methods to SDK

### DIFF
--- a/examples/outcome_routing.py
+++ b/examples/outcome_routing.py
@@ -1,0 +1,101 @@
+"""Example: Outcome-Conditioned Routing with Kalibr
+
+This example shows how to use Kalibr's outcome routing to:
+1. Query for the best model based on historical success rates
+2. Report outcomes to teach Kalibr what works
+
+The system learns over time which execution paths lead to success
+for each goal, and recommends those paths to future executions.
+"""
+
+import os
+from kalibr import get_policy, report_outcome, get_trace_id
+
+# Ensure environment is configured
+# export KALIBR_API_KEY=your-api-key
+# export KALIBR_TENANT_ID=your-tenant-id
+
+
+def book_meeting_agent():
+    """Example agent that books meetings."""
+
+    # Step 1: Query Kalibr for the best execution path
+    try:
+        policy = get_policy(goal="book_meeting")
+
+        print(f"Kalibr recommends: {policy['recommended_model']}")
+        print(f"  Provider: {policy['recommended_provider']}")
+        print(f"  Success rate: {policy['outcome_success_rate']:.0%}")
+        print(f"  Confidence: {policy['confidence']:.0%}")
+        print(f"  Reasoning: {policy['reasoning']}")
+
+        # Use the recommended model
+        model = policy["recommended_model"]
+        provider = policy["recommended_provider"]
+
+    except Exception as e:
+        # Fall back to default if intelligence unavailable
+        print(f"Intelligence unavailable, using default: {e}")
+        model = "gpt-4o"
+        provider = "openai"
+
+    # Step 2: Execute your agent logic
+    trace_id = get_trace_id()  # Get current trace ID from Kalibr context
+
+    try:
+        # ... your actual agent logic here ...
+        # This would call the LLM, use tools, etc.
+
+        success = True  # Assume success for this example
+        meeting_booked = True
+
+    except Exception as e:
+        success = False
+        meeting_booked = False
+        failure_reason = str(e)
+
+    # Step 3: Report the outcome to Kalibr
+    if success and meeting_booked:
+        report_outcome(
+            trace_id=trace_id,
+            goal="book_meeting",
+            success=True,
+            score=1.0,  # Optional: quality score
+        )
+        print("Meeting booked! Outcome reported to Kalibr.")
+    else:
+        report_outcome(
+            trace_id=trace_id,
+            goal="book_meeting",
+            success=False,
+            failure_reason=failure_reason if not success else "meeting_not_booked",
+        )
+        print("Failed to book meeting. Outcome reported to Kalibr.")
+
+    # Over time, Kalibr learns which models/paths work best for booking meetings
+    # and will recommend those to future executions.
+
+
+def main():
+    """Run the example."""
+    print("=" * 60)
+    print("Kalibr Outcome-Conditioned Routing Example")
+    print("=" * 60)
+    print()
+
+    # Check for required env vars
+    if not os.getenv("KALIBR_API_KEY"):
+        print("Warning: Set KALIBR_API_KEY environment variable")
+        print("   export KALIBR_API_KEY=your-api-key")
+        return
+
+    if not os.getenv("KALIBR_TENANT_ID"):
+        print("Warning: Set KALIBR_TENANT_ID environment variable")
+        print("   export KALIBR_TENANT_ID=your-tenant-id")
+        return
+
+    book_meeting_agent()
+
+
+if __name__ == "__main__":
+    main()

--- a/kalibr/__init__.py
+++ b/kalibr/__init__.py
@@ -71,6 +71,16 @@ from .trace_capsule import TraceCapsule, get_or_create_capsule
 from .tracer import SpanContext, Tracer
 from .utils import load_config_from_env
 
+# ============================================================================
+# INTELLIGENCE & OUTCOME ROUTING (v1.2.0)
+# ============================================================================
+from .intelligence import (
+    KalibrIntelligence,
+    get_policy,
+    report_outcome,
+    get_recommendation,
+)
+
 if os.getenv("KALIBR_AUTO_INSTRUMENT", "true").lower() == "true":
     # Setup OpenTelemetry collector
     try:
@@ -127,4 +137,11 @@ __all__ = [
     "setup_collector",
     "get_tracer_provider",
     "is_collector_configured",
+    # ========================================================================
+    # INTELLIGENCE & OUTCOME ROUTING (v1.2.0)
+    # ========================================================================
+    "KalibrIntelligence",
+    "get_policy",
+    "report_outcome",
+    "get_recommendation",
 ]

--- a/kalibr/intelligence.py
+++ b/kalibr/intelligence.py
@@ -1,0 +1,305 @@
+"""Kalibr Intelligence Client - Query execution intelligence and report outcomes.
+
+This module enables the outcome-conditioned routing loop:
+1. Before executing: query get_policy() to get the best path for your goal
+2. After executing: call report_outcome() to teach Kalibr what worked
+
+Example:
+    from kalibr import get_policy, report_outcome
+
+    # Before executing - get best path
+    policy = get_policy(goal="book_meeting")
+    model = policy["recommended_model"]  # Use this model
+
+    # After executing - report what happened
+    report_outcome(
+        trace_id=trace_id,
+        goal="book_meeting",
+        success=True
+    )
+"""
+
+import os
+from typing import Any, Optional
+
+import httpx
+
+# Default intelligence API endpoint
+DEFAULT_INTELLIGENCE_URL = "https://kalibr-intelligence.fly.dev"
+
+
+class KalibrIntelligence:
+    """Client for Kalibr Intelligence API.
+
+    Provides methods to query execution policies and report outcomes
+    for the outcome-conditioned routing loop.
+
+    Args:
+        api_key: Kalibr API key (or set KALIBR_API_KEY env var)
+        tenant_id: Tenant identifier (or set KALIBR_TENANT_ID env var)
+        base_url: Intelligence API base URL (or set KALIBR_INTELLIGENCE_URL env var)
+        timeout: Request timeout in seconds
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        tenant_id: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 10.0,
+    ):
+        self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
+        self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "")
+        self.base_url = (
+            base_url
+            or os.getenv("KALIBR_INTELLIGENCE_URL", DEFAULT_INTELLIGENCE_URL)
+        ).rstrip("/")
+        self.timeout = timeout
+        self._client = httpx.Client(timeout=timeout)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json: dict | None = None,
+    ) -> httpx.Response:
+        """Make authenticated request to intelligence API."""
+        headers = {
+            "X-API-Key": self.api_key,
+            "X-Tenant-ID": self.tenant_id,
+            "Content-Type": "application/json",
+        }
+
+        url = f"{self.base_url}{path}"
+        response = self._client.request(method, url, json=json, headers=headers)
+        response.raise_for_status()
+        return response
+
+    def get_policy(
+        self,
+        goal: str,
+        task_type: str | None = None,
+        constraints: dict | None = None,
+        window_hours: int = 168,
+    ) -> dict[str, Any]:
+        """Get execution policy for a goal.
+
+        Returns the historically best-performing path for achieving
+        the specified goal, based on outcome data.
+
+        Args:
+            goal: The goal to optimize for (e.g., "book_meeting", "resolve_ticket")
+            task_type: Optional task type filter (e.g., "code", "summarize")
+            constraints: Optional constraints dict with keys:
+                - max_cost_usd: Maximum cost per request
+                - max_latency_ms: Maximum latency
+                - min_quality: Minimum quality score (0-1)
+                - min_confidence: Minimum statistical confidence (0-1)
+                - max_risk: Maximum risk score (0-1)
+            window_hours: Time window for pattern analysis (default 1 week)
+
+        Returns:
+            dict with:
+                - goal: The goal queried
+                - recommended_model: Best model for this goal
+                - recommended_provider: Provider for the recommended model
+                - outcome_success_rate: Historical success rate (0-1)
+                - outcome_sample_count: Number of outcomes in the data
+                - confidence: Statistical confidence in recommendation
+                - risk_score: Risk score (lower is better)
+                - reasoning: Human-readable explanation
+                - alternatives: List of alternative models
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            policy = intelligence.get_policy(goal="book_meeting")
+            print(f"Use {policy['recommended_model']} - {policy['outcome_success_rate']:.0%} success rate")
+        """
+        response = self._request(
+            "POST",
+            "/api/v1/intelligence/policy",
+            json={
+                "goal": goal,
+                "task_type": task_type,
+                "constraints": constraints,
+                "window_hours": window_hours,
+            },
+        )
+        return response.json()
+
+    def report_outcome(
+        self,
+        trace_id: str,
+        goal: str,
+        success: bool,
+        score: float | None = None,
+        failure_reason: str | None = None,
+        metadata: dict | None = None,
+    ) -> dict[str, Any]:
+        """Report execution outcome for a goal.
+
+        This is the feedback loop that teaches Kalibr what works.
+        Call this after your agent completes (or fails) a task.
+
+        Args:
+            trace_id: The trace ID from the execution
+            goal: The goal this execution was trying to achieve
+            success: Whether the goal was achieved
+            score: Optional quality score (0-1) for more granular feedback
+            failure_reason: Optional reason for failure (helps with debugging)
+            metadata: Optional additional context as a dict
+
+        Returns:
+            dict with:
+                - status: "accepted" if successful
+                - trace_id: The trace ID recorded
+                - goal: The goal recorded
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            # Success case
+            report_outcome(trace_id="abc123", goal="book_meeting", success=True)
+
+            # Failure case with reason
+            report_outcome(
+                trace_id="abc123",
+                goal="book_meeting",
+                success=False,
+                failure_reason="calendar_conflict"
+            )
+        """
+        response = self._request(
+            "POST",
+            "/api/v1/intelligence/report-outcome",
+            json={
+                "trace_id": trace_id,
+                "goal": goal,
+                "success": success,
+                "score": score,
+                "failure_reason": failure_reason,
+                "metadata": metadata,
+            },
+        )
+        return response.json()
+
+    def get_recommendation(
+        self,
+        task_type: str,
+        goal: str | None = None,
+        optimize_for: str = "balanced",
+        constraints: dict | None = None,
+        window_hours: int = 168,
+    ) -> dict[str, Any]:
+        """Get model recommendation for a task type.
+
+        This is the original recommendation endpoint. For goal-based
+        optimization, prefer get_policy() instead.
+
+        Args:
+            task_type: Type of task (e.g., "summarize", "code", "qa")
+            goal: Optional goal for outcome-based optimization
+            optimize_for: Optimization target - one of:
+                - "cost": Minimize cost
+                - "quality": Maximize output quality
+                - "latency": Minimize response time
+                - "balanced": Balance all factors (default)
+                - "cost_efficiency": Maximize quality-per-dollar
+                - "outcome": Optimize for goal success rate
+            constraints: Optional constraints dict
+            window_hours: Time window for pattern analysis
+
+        Returns:
+            dict with recommendation, alternatives, stats, reasoning
+        """
+        response = self._request(
+            "POST",
+            "/api/v1/intelligence/recommend",
+            json={
+                "task_type": task_type,
+                "goal": goal,
+                "optimize_for": optimize_for,
+                "constraints": constraints,
+                "window_hours": window_hours,
+            },
+        )
+        return response.json()
+
+    def close(self):
+        """Close the HTTP client."""
+        self._client.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+# Module-level singleton for convenience functions
+_intelligence_client: KalibrIntelligence | None = None
+
+
+def _get_intelligence_client() -> KalibrIntelligence:
+    """Get or create the singleton intelligence client."""
+    global _intelligence_client
+    if _intelligence_client is None:
+        _intelligence_client = KalibrIntelligence()
+    return _intelligence_client
+
+
+def get_policy(goal: str, **kwargs) -> dict[str, Any]:
+    """Get execution policy for a goal.
+
+    Convenience function that uses the default intelligence client.
+    See KalibrIntelligence.get_policy for full documentation.
+
+    Args:
+        goal: The goal to optimize for
+        **kwargs: Additional arguments (task_type, constraints, window_hours)
+
+    Returns:
+        Policy dict with recommended_model, outcome_success_rate, etc.
+
+    Example:
+        from kalibr import get_policy
+
+        policy = get_policy(goal="book_meeting")
+        model = policy["recommended_model"]
+    """
+    return _get_intelligence_client().get_policy(goal, **kwargs)
+
+
+def report_outcome(trace_id: str, goal: str, success: bool, **kwargs) -> dict[str, Any]:
+    """Report execution outcome for a goal.
+
+    Convenience function that uses the default intelligence client.
+    See KalibrIntelligence.report_outcome for full documentation.
+
+    Args:
+        trace_id: The trace ID from the execution
+        goal: The goal this execution was trying to achieve
+        success: Whether the goal was achieved
+        **kwargs: Additional arguments (score, failure_reason, metadata)
+
+    Returns:
+        Response dict with status confirmation
+
+    Example:
+        from kalibr import report_outcome
+
+        report_outcome(trace_id="abc123", goal="book_meeting", success=True)
+    """
+    return _get_intelligence_client().report_outcome(trace_id, goal, success, **kwargs)
+
+
+def get_recommendation(task_type: str, **kwargs) -> dict[str, Any]:
+    """Get model recommendation for a task type.
+
+    Convenience function that uses the default intelligence client.
+    See KalibrIntelligence.get_recommendation for full documentation.
+    """
+    return _get_intelligence_client().get_recommendation(task_type, **kwargs)

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -1,0 +1,175 @@
+"""Tests for Kalibr Intelligence client."""
+
+import pytest
+from unittest.mock import Mock, patch
+import httpx
+
+from kalibr.intelligence import (
+    KalibrIntelligence,
+    get_policy,
+    report_outcome,
+    get_recommendation,
+    _get_intelligence_client,
+)
+
+
+class TestKalibrIntelligence:
+    """Tests for KalibrIntelligence client class."""
+
+    def test_init_defaults(self):
+        """Test client initializes with defaults."""
+        client = KalibrIntelligence()
+        assert client.base_url == "https://kalibr-intelligence.fly.dev"
+        assert client.timeout == 10.0
+
+    def test_init_custom_values(self):
+        """Test client initializes with custom values."""
+        client = KalibrIntelligence(
+            api_key="test-key",
+            tenant_id="test-tenant",
+            base_url="https://custom.url",
+            timeout=30.0,
+        )
+        assert client.api_key == "test-key"
+        assert client.tenant_id == "test-tenant"
+        assert client.base_url == "https://custom.url"
+        assert client.timeout == 30.0
+
+    def test_init_from_env(self, monkeypatch):
+        """Test client reads from environment variables."""
+        monkeypatch.setenv("KALIBR_API_KEY", "env-key")
+        monkeypatch.setenv("KALIBR_TENANT_ID", "env-tenant")
+        monkeypatch.setenv("KALIBR_INTELLIGENCE_URL", "https://env.url")
+
+        client = KalibrIntelligence()
+        assert client.api_key == "env-key"
+        assert client.tenant_id == "env-tenant"
+        assert client.base_url == "https://env.url"
+
+    @patch.object(httpx.Client, "request")
+    def test_get_policy(self, mock_request):
+        """Test get_policy makes correct API call."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "goal": "book_meeting",
+            "recommended_model": "claude-3-sonnet",
+            "recommended_provider": "anthropic",
+            "outcome_success_rate": 0.73,
+            "outcome_sample_count": 150,
+            "confidence": 0.82,
+            "risk_score": 0.15,
+            "reasoning": "outcome score | high confidence",
+            "alternatives": [],
+        }
+        mock_response.raise_for_status = Mock()
+        mock_request.return_value = mock_response
+
+        client = KalibrIntelligence(api_key="test", tenant_id="test")
+        result = client.get_policy(goal="book_meeting")
+
+        assert result["recommended_model"] == "claude-3-sonnet"
+        assert result["outcome_success_rate"] == 0.73
+
+        # Verify request was made correctly
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "POST"
+        assert "/api/v1/intelligence/policy" in call_args[0][1]
+
+    @patch.object(httpx.Client, "request")
+    def test_report_outcome_success(self, mock_request):
+        """Test report_outcome for success case."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "status": "accepted",
+            "trace_id": "trace-123",
+            "goal": "book_meeting",
+        }
+        mock_response.raise_for_status = Mock()
+        mock_request.return_value = mock_response
+
+        client = KalibrIntelligence(api_key="test", tenant_id="test")
+        result = client.report_outcome(
+            trace_id="trace-123",
+            goal="book_meeting",
+            success=True,
+        )
+
+        assert result["status"] == "accepted"
+
+        # Verify request body
+        call_args = mock_request.call_args
+        request_body = call_args[1]["json"]
+        assert request_body["trace_id"] == "trace-123"
+        assert request_body["goal"] == "book_meeting"
+        assert request_body["success"] is True
+
+    @patch.object(httpx.Client, "request")
+    def test_report_outcome_failure_with_reason(self, mock_request):
+        """Test report_outcome for failure case with reason."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "status": "accepted",
+            "trace_id": "trace-456",
+            "goal": "book_meeting",
+        }
+        mock_response.raise_for_status = Mock()
+        mock_request.return_value = mock_response
+
+        client = KalibrIntelligence(api_key="test", tenant_id="test")
+        result = client.report_outcome(
+            trace_id="trace-456",
+            goal="book_meeting",
+            success=False,
+            failure_reason="calendar_conflict",
+            score=0.3,
+        )
+
+        assert result["status"] == "accepted"
+
+        # Verify request body includes failure details
+        call_args = mock_request.call_args
+        request_body = call_args[1]["json"]
+        assert request_body["success"] is False
+        assert request_body["failure_reason"] == "calendar_conflict"
+        assert request_body["score"] == 0.3
+
+    def test_context_manager(self):
+        """Test client works as context manager."""
+        with KalibrIntelligence() as client:
+            assert client is not None
+        # Client should be closed after context
+
+
+class TestConvenienceFunctions:
+    """Tests for module-level convenience functions."""
+
+    @patch("kalibr.intelligence._get_intelligence_client")
+    def test_get_policy_convenience(self, mock_get_client):
+        """Test get_policy convenience function."""
+        mock_client = Mock()
+        mock_client.get_policy.return_value = {"recommended_model": "gpt-4"}
+        mock_get_client.return_value = mock_client
+
+        result = get_policy(goal="test_goal", task_type="code")
+
+        mock_client.get_policy.assert_called_once_with("test_goal", task_type="code")
+        assert result["recommended_model"] == "gpt-4"
+
+    @patch("kalibr.intelligence._get_intelligence_client")
+    def test_report_outcome_convenience(self, mock_get_client):
+        """Test report_outcome convenience function."""
+        mock_client = Mock()
+        mock_client.report_outcome.return_value = {"status": "accepted"}
+        mock_get_client.return_value = mock_client
+
+        result = report_outcome(
+            trace_id="trace-123",
+            goal="test_goal",
+            success=True,
+        )
+
+        mock_client.report_outcome.assert_called_once_with(
+            "trace-123", "test_goal", True
+        )
+        assert result["status"] == "accepted"


### PR DESCRIPTION
Add KalibrIntelligence client with get_policy and report_outcome methods for the outcome-conditioned routing loop:
- get_policy() queries Kalibr for the best execution path based on historical success rates before running an agent
- report_outcome() reports execution results to teach Kalibr what works

This enables teams to close the feedback loop and improve routing over time based on real-world outcomes.