### PR TITLE
fix: cleanup for open source release

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,19 +129,28 @@ from kalibr import TraceCapsule, get_or_create_capsule
 
 # Agent 1: Create capsule and add hop
 capsule = get_or_create_capsule()
-capsule.add_hop(
-    agent_id="agent-1",
-    model="gpt-4o",
-    latency_ms=150,
-    cost_usd=0.002
-)
+capsule.append_hop({
+    "provider": "openai",
+    "operation": "chat_completion",
+    "model": "gpt-4o",
+    "duration_ms": 150,
+    "cost_usd": 0.002,
+    "status": "success"
+})
 
 # Pass to Agent 2 via HTTP header
-headers = {"X-Kalibr-Capsule": capsule.to_header()}
+headers = {"X-Kalibr-Capsule": capsule.to_json()}
 
 # Agent 2: Receive and continue
-capsule = TraceCapsule.from_header(headers["X-Kalibr-Capsule"])
-capsule.add_hop(agent_id="agent-2", model="claude-3-5-sonnet-20241022", ...)
+capsule = TraceCapsule.from_json(headers["X-Kalibr-Capsule"])
+capsule.append_hop({
+    "provider": "anthropic",
+    "operation": "chat_completion",
+    "model": "claude-3-5-sonnet-20241022",
+    "duration_ms": 200,
+    "cost_usd": 0.003,
+    "status": "success"
+})
 ```
 
 ## Framework Integrations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Email us at: **support@kalibr.systems**
+Email us at: **security@kalibr.systems**
 
 Include:
 - Description of the vulnerability

--- a/kalibr/cli/capsule_cmd.py
+++ b/kalibr/cli/capsule_cmd.py
@@ -63,7 +63,7 @@ def capsule(
         kalibr capsule abc-123-def --export --output capsule.json
 
         # Specify custom API URL
-        kalibr capsule abc-123-def -u https://api.kalibr.io
+        kalibr capsule abc-123-def -u https://api.kalibr.systems
     """
     # Determine API base URL
     base_url = api_url or "https://api.kalibr.systems"

--- a/kalibr/cli/run.py
+++ b/kalibr/cli/run.py
@@ -47,7 +47,7 @@ def run(
         kalibr run weather.py --runtime fly.io
 
         # Custom backend
-        kalibr run weather.py --backend-url https://api.kalibr.io
+        kalibr run weather.py --backend-url https://api.kalibr.systems
     """
     # Validate file exists
     agent_path = Path(file_path).resolve()

--- a/kalibr_crewai/__init__.py
+++ b/kalibr_crewai/__init__.py
@@ -46,7 +46,7 @@ Usage with Auto-Instrumentation:
 
 Environment Variables:
     KALIBR_API_KEY: API key for authentication
-    KALIBR_ENDPOINT: Backend endpoint URL
+    KALIBR_COLLECTOR_URL: Backend endpoint URL
     KALIBR_TENANT_ID: Tenant identifier
     KALIBR_ENVIRONMENT: Environment (prod/staging/dev)
     KALIBR_SERVICE: Service name

--- a/kalibr_langchain/__init__.py
+++ b/kalibr_langchain/__init__.py
@@ -29,7 +29,7 @@ Usage:
 
 Environment Variables:
     KALIBR_API_KEY: API key for authentication
-    KALIBR_ENDPOINT: Backend endpoint URL
+    KALIBR_COLLECTOR_URL: Backend endpoint URL
     KALIBR_TENANT_ID: Tenant identifier
     KALIBR_ENVIRONMENT: Environment (prod/staging/dev)
     KALIBR_SERVICE: Service name

--- a/kalibr_openai_agents/__init__.py
+++ b/kalibr_openai_agents/__init__.py
@@ -26,7 +26,7 @@ Usage:
 
 Environment Variables:
     KALIBR_API_KEY: API key for authentication
-    KALIBR_ENDPOINT: Backend endpoint URL
+    KALIBR_COLLECTOR_URL: Backend endpoint URL
     KALIBR_TENANT_ID: Tenant identifier
     KALIBR_ENVIRONMENT: Environment (prod/staging/dev)
     KALIBR_SERVICE: Service name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.2.0"
 description = "Unified LLM Observability & Multi-Model AI Integration Framework - Deploy to GPT, Claude, Gemini, Copilot with full telemetry."
 authors = [{name = "Kalibr Team", email = "support@kalibr.systems"}]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "Apache-2.0"}
 keywords = [
     "ai", "mcp", "gpt", "claude", "gemini", "copilot",

--- a/tests/test_capsule_builder.py
+++ b/tests/test_capsule_builder.py
@@ -189,7 +189,7 @@ class TestCapsuleCLI:
         test_cases = [
             ("http://localhost:8001", "trace-123", False, "http://localhost:8001/api/capsule/trace-123"),
             ("http://localhost:8001/", "trace-456", False, "http://localhost:8001/api/capsule/trace-456"),
-            ("https://api.kalibr.io", "trace-789", True, "https://api.kalibr.io/api/capsule/trace-789/export"),
+            ("https://api.kalibr.systems", "trace-789", True, "https://api.kalibr.systems/api/capsule/trace-789/export"),
         ]
         
         for base_url, trace_id, export, expected in test_cases:


### PR DESCRIPTION
- Fix TraceCapsule example in README (wrong method names)
- Replace old kalibr.io domain with kalibr.systems
- Fix security email in SECURITY.md
- Update Python version requirement to 3.9+
- Standardize KALIBR_COLLECTOR_URL env var name in integration docs