### PR TITLE
fix: use support email for security reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ To add a new framework integration:
 
 ## Security Issues
 
-If you discover a security vulnerability, please **do not** open a public issue. Instead, email security@kalibr.systems with details. We will respond promptly and work with you to address the issue.
+If you discover a security vulnerability, please **do not** open a public issue. Instead, email support@kalibr.systems with details. We will respond promptly and work with you to address the issue.
 
 ## Questions and Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Email us at: **security@kalibr.systems**
+Email us at: **support@kalibr.systems**
 
 Include:
 - Description of the vulnerability


### PR DESCRIPTION
We don't have a separate security inbox - all security reports should go to support@kalibr.systems.