### PR TITLE
feat: add routing methods for path registration and intelligent routing

### DIFF
--- a/kalibr/__init__.py
+++ b/kalibr/__init__.py
@@ -89,6 +89,8 @@ from .intelligence import (
     get_policy,
     report_outcome,
     get_recommendation,
+    register_path,
+    decide,
 )
 
 if os.getenv("KALIBR_AUTO_INSTRUMENT", "true").lower() == "true":
@@ -159,4 +161,6 @@ __all__ = [
     "get_policy",
     "report_outcome",
     "get_recommendation",
+    "register_path",
+    "decide",
 ]

--- a/kalibr/intelligence.py
+++ b/kalibr/intelligence.py
@@ -4,7 +4,7 @@ This module enables the outcome-conditioned routing loop:
 1. Before executing: query get_policy() to get the best path for your goal
 2. After executing: call report_outcome() to teach Kalibr what worked
 
-Example:
+Example - Policy-based routing:
     from kalibr import get_policy, report_outcome
 
     # Before executing - get best path
@@ -17,6 +17,17 @@ Example:
         goal="book_meeting",
         success=True
     )
+
+Example - Path registration and intelligent routing:
+    from kalibr import register_path, decide
+
+    # Register paths for a goal
+    register_path(goal="book_meeting", model_id="gpt-4", tool_id="calendar_tool")
+    register_path(goal="book_meeting", model_id="claude-3-opus")
+
+    # Get intelligent routing decision
+    decision = decide(goal="book_meeting")
+    model = decision["model_id"]  # Selected based on outcomes
 """
 
 from __future__ import annotations
@@ -64,6 +75,7 @@ class KalibrIntelligence:
         method: str,
         path: str,
         json: dict | None = None,
+        params: dict | None = None,
     ) -> httpx.Response:
         """Make authenticated request to intelligence API."""
         headers = {
@@ -73,7 +85,7 @@ class KalibrIntelligence:
         }
 
         url = f"{self.base_url}{path}"
-        response = self._client.request(method, url, json=json, headers=headers)
+        response = self._client.request(method, url, json=json, params=params, headers=headers)
         response.raise_for_status()
         return response
 
@@ -230,6 +242,252 @@ class KalibrIntelligence:
         )
         return response.json()
 
+    # =========================================================================
+    # ROUTING METHODS
+    # =========================================================================
+
+    def register_path(
+        self,
+        goal: str,
+        model_id: str,
+        tool_id: str | None = None,
+        params: dict | None = None,
+        risk_level: str = "low",
+    ) -> dict[str, Any]:
+        """Register a new routing path for a goal.
+
+        Creates a path that maps a goal to a specific model (and optionally tool)
+        configuration. This path can then be selected by the decide() method.
+
+        Args:
+            goal: The goal this path is for (e.g., "book_meeting", "resolve_ticket")
+            model_id: The model identifier to use (e.g., "gpt-4", "claude-3-opus")
+            tool_id: Optional tool identifier if this path uses a specific tool
+            params: Optional parameters dict for the path configuration
+            risk_level: Risk level for this path - "low", "medium", or "high"
+
+        Returns:
+            dict with the created path including:
+                - path_id: Unique identifier for the path
+                - goal: The goal
+                - model_id: The model
+                - tool_id: The tool (if specified)
+                - params: The parameters (if specified)
+                - risk_level: The risk level
+                - created_at: Creation timestamp
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            path = intelligence.register_path(
+                goal="book_meeting",
+                model_id="gpt-4",
+                tool_id="calendar_tool",
+                risk_level="low"
+            )
+            print(f"Created path: {path['path_id']}")
+        """
+        response = self._request(
+            "POST",
+            "/api/v1/routing/paths",
+            json={
+                "goal": goal,
+                "model_id": model_id,
+                "tool_id": tool_id,
+                "params": params,
+                "risk_level": risk_level,
+            },
+        )
+        return response.json()
+
+    def list_paths(
+        self,
+        goal: str | None = None,
+        include_disabled: bool = False,
+    ) -> dict[str, Any]:
+        """List registered routing paths.
+
+        Args:
+            goal: Optional goal to filter paths by
+            include_disabled: Whether to include disabled paths (default False)
+
+        Returns:
+            dict with:
+                - paths: List of path objects
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            result = intelligence.list_paths(goal="book_meeting")
+            for path in result["paths"]:
+                print(f"{path['path_id']}: {path['model_id']}")
+        """
+        params = {}
+        if goal is not None:
+            params["goal"] = goal
+        if include_disabled:
+            params["include_disabled"] = "true"
+
+        response = self._request(
+            "GET",
+            "/api/v1/routing/paths",
+            params=params if params else None,
+        )
+        return response.json()
+
+    def disable_path(self, path_id: str) -> dict[str, Any]:
+        """Disable a routing path.
+
+        Disables a path so it won't be selected by decide(). The path
+        data is retained for historical analysis.
+
+        Args:
+            path_id: The unique identifier of the path to disable
+
+        Returns:
+            dict with:
+                - status: "disabled" if successful
+                - path_id: The disabled path ID
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            result = intelligence.disable_path("path_abc123")
+            print(f"Status: {result['status']}")
+        """
+        response = self._request(
+            "DELETE",
+            f"/api/v1/routing/paths/{path_id}",
+        )
+        return response.json()
+
+    def decide(
+        self,
+        goal: str,
+        task_risk_level: str = "low",
+    ) -> dict[str, Any]:
+        """Get routing decision for a goal.
+
+        Uses outcome data and exploration/exploitation strategy to decide
+        which path to use for achieving the specified goal.
+
+        Args:
+            goal: The goal to route for (e.g., "book_meeting")
+            task_risk_level: Risk tolerance for this task - "low", "medium", or "high"
+
+        Returns:
+            dict with:
+                - model_id: The selected model
+                - tool_id: The selected tool (if any)
+                - params: Additional parameters (if any)
+                - reason: Human-readable explanation of the decision
+                - confidence: Confidence score (0-1)
+                - is_exploration: Whether this is an exploration choice
+                - path_id: The selected path ID
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            decision = intelligence.decide(goal="book_meeting")
+            model = decision["model_id"]
+            print(f"Using {model} ({decision['reason']})")
+        """
+        response = self._request(
+            "POST",
+            "/api/v1/routing/decide",
+            json={
+                "goal": goal,
+                "task_risk_level": task_risk_level,
+            },
+        )
+        return response.json()
+
+    def set_exploration_config(
+        self,
+        goal: str = "*",
+        exploration_rate: float = 0.1,
+        min_samples_before_exploit: int = 20,
+        rollback_threshold: float = 0.3,
+        staleness_days: int = 7,
+        exploration_on_high_risk: bool = False,
+    ) -> dict[str, Any]:
+        """Set exploration/exploitation configuration for routing.
+
+        Configures how the decide() method balances exploring new paths
+        vs exploiting known good paths.
+
+        Args:
+            goal: Goal to configure, or "*" for default config
+            exploration_rate: Probability of exploring (0-1, default 0.1)
+            min_samples_before_exploit: Minimum outcomes before exploiting (default 20)
+            rollback_threshold: Performance drop threshold to rollback (default 0.3)
+            staleness_days: Days before reexploring stale paths (default 7)
+            exploration_on_high_risk: Whether to explore on high-risk tasks (default False)
+
+        Returns:
+            dict with the saved configuration
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            config = intelligence.set_exploration_config(
+                goal="book_meeting",
+                exploration_rate=0.2,
+                min_samples_before_exploit=10
+            )
+        """
+        response = self._request(
+            "POST",
+            "/api/v1/routing/config",
+            json={
+                "goal": goal,
+                "exploration_rate": exploration_rate,
+                "min_samples_before_exploit": min_samples_before_exploit,
+                "rollback_threshold": rollback_threshold,
+                "staleness_days": staleness_days,
+                "exploration_on_high_risk": exploration_on_high_risk,
+            },
+        )
+        return response.json()
+
+    def get_exploration_config(self, goal: str | None = None) -> dict[str, Any]:
+        """Get exploration/exploitation configuration.
+
+        Args:
+            goal: Optional goal to get config for (returns default if not found)
+
+        Returns:
+            dict with configuration values:
+                - goal: The goal this config applies to
+                - exploration_rate: Exploration probability
+                - min_samples_before_exploit: Minimum samples before exploiting
+                - rollback_threshold: Rollback threshold
+                - staleness_days: Staleness threshold in days
+                - exploration_on_high_risk: Whether exploration is allowed on high-risk
+
+        Raises:
+            httpx.HTTPStatusError: If the API returns an error
+
+        Example:
+            config = intelligence.get_exploration_config(goal="book_meeting")
+            print(f"Exploration rate: {config['exploration_rate']}")
+        """
+        params = {}
+        if goal is not None:
+            params["goal"] = goal
+
+        response = self._request(
+            "GET",
+            "/api/v1/routing/config",
+            params=params if params else None,
+        )
+        return response.json()
+
     def close(self):
         """Close the HTTP client."""
         self._client.close()
@@ -315,3 +573,72 @@ def get_recommendation(task_type: str, **kwargs) -> dict[str, Any]:
     See KalibrIntelligence.get_recommendation for full documentation.
     """
     return _get_intelligence_client().get_recommendation(task_type, **kwargs)
+
+
+def register_path(
+    goal: str,
+    model_id: str,
+    tool_id: str | None = None,
+    params: dict | None = None,
+    risk_level: str = "low",
+    tenant_id: str | None = None,
+) -> dict[str, Any]:
+    """Register a new routing path for a goal.
+
+    Convenience function that uses the default intelligence client.
+    See KalibrIntelligence.register_path for full documentation.
+
+    Args:
+        goal: The goal this path is for
+        model_id: The model identifier to use
+        tool_id: Optional tool identifier
+        params: Optional parameters dict
+        risk_level: Risk level - "low", "medium", or "high"
+        tenant_id: Optional tenant ID override
+
+    Returns:
+        dict with the created path
+
+    Example:
+        from kalibr import register_path
+
+        path = register_path(
+            goal="book_meeting",
+            model_id="gpt-4",
+            tool_id="calendar_tool"
+        )
+    """
+    client = _get_intelligence_client()
+    if tenant_id:
+        client = KalibrIntelligence(tenant_id=tenant_id)
+    return client.register_path(goal, model_id, tool_id, params, risk_level)
+
+
+def decide(
+    goal: str,
+    task_risk_level: str = "low",
+    tenant_id: str | None = None,
+) -> dict[str, Any]:
+    """Get routing decision for a goal.
+
+    Convenience function that uses the default intelligence client.
+    See KalibrIntelligence.decide for full documentation.
+
+    Args:
+        goal: The goal to route for
+        task_risk_level: Risk tolerance - "low", "medium", or "high"
+        tenant_id: Optional tenant ID override
+
+    Returns:
+        dict with model_id, tool_id, params, reason, confidence, etc.
+
+    Example:
+        from kalibr import decide
+
+        decision = decide(goal="book_meeting")
+        model = decision["model_id"]
+    """
+    client = _get_intelligence_client()
+    if tenant_id:
+        client = KalibrIntelligence(tenant_id=tenant_id)
+    return client.decide(goal, task_risk_level)


### PR DESCRIPTION
Add 6 new routing methods to KalibrIntelligence class:
- register_path(): POST to /api/v1/routing/paths
- list_paths(): GET from /api/v1/routing/paths
- disable_path(): DELETE /api/v1/routing/paths/{path_id}
- decide(): POST to /api/v1/routing/decide
- set_exploration_config(): POST to /api/v1/routing/config
- get_exploration_config(): GET from /api/v1/routing/config

Add module-level convenience functions:
- register_path()
- decide()

These methods enable path-based routing with exploration/exploitation strategies for intelligent model selection based on outcome data.