### PR TITLE
fix: send correct telemetry with real model name and cost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kalibr"
-version = "1.2.0"
+version = "1.2.1"
 description = "Unified LLM Observability & Multi-Model AI Integration Framework - Deploy to GPT, Claude, Gemini, Copilot with full telemetry."
 authors = [{name = "Kalibr Team", email = "support@kalibr.systems"}]
 readme = "README.md"


### PR DESCRIPTION
- Extract model name from agent's LLM config (agent.llm.model, agent.llm.model_name, or parse from string like "openai/gpt-4o-mini")
- Calculate real cost using CostAdapterFactory instead of hardcoding 0.0
- Add _extract_model_from_agent() and _calculate_cost() helper functions
- Update KalibrAgentCallback and KalibrTaskCallback to support agent reference for model extraction
- Add set_agent() method to callbacks for setting agent reference after initialization
- Bump version to 1.2.1