### PR TITLE
fix: enrich CrewAI OTel spans with Kalibr telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kalibr"
-version = "1.2.2"
+version = "1.2.3"
 description = "Unified LLM Observability & Multi-Model AI Integration Framework - Deploy to GPT, Claude, Gemini, Copilot with full telemetry."
 authors = [{name = "Kalibr Team", email = "support@kalibr.systems"}]
 readme = "README.md"


### PR DESCRIPTION
Add kalibr.* attributes to CrewAI's OTel spans with cost, tokens, model, and provider data from Kalibr's telemetry. This ensures CrewAI spans in the dashboard show accurate cost/token information instead of $0.00/0 tokens/"unknown" model.

Applies to both sync (kickoff) and async (kickoff_async) methods.