### PR TITLE
Add LangChain-compatible chat model with Kalibr routing

### DIFF
--- a/kalibr_langchain/__init__.py
+++ b/kalibr_langchain/__init__.py
@@ -1,4 +1,4 @@
-"""Kalibr LangChain Integration - Observability for LangChain applications.
+"""Kalibr LangChain Integration - Observability and Routing for LangChain applications.
 
 This package provides a callback handler that integrates LangChain with
 Kalibr's observability platform, capturing:
@@ -39,9 +39,11 @@ __version__ = "0.1.0"
 
 from .callback import KalibrCallbackHandler
 from .async_callback import AsyncKalibrCallbackHandler
+from .chat_model import KalibrChatModel
 
 __all__ = [
     "KalibrCallbackHandler",
     "AsyncKalibrCallbackHandler",
+    "KalibrChatModel",
     "__version__",
 ]

--- a/kalibr_langchain/chat_model.py
+++ b/kalibr_langchain/chat_model.py
@@ -1,0 +1,103 @@
+"""
+Kalibr LangChain Chat Model - Routes requests through Kalibr.
+"""
+
+from typing import Any, List, Optional
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+
+class KalibrChatModel(BaseChatModel):
+    """
+    LangChain chat model that routes through Kalibr.
+
+    Example:
+        from kalibr import Router
+
+        router = Router(goal="summarize", paths=["gpt-4o", "claude-3"])
+        llm = router.as_langchain()
+
+        chain = prompt | llm | parser
+        result = chain.invoke({"text": "..."})
+    """
+
+    router: Any  # Kalibr Router instance
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def _llm_type(self) -> str:
+        return "kalibr"
+
+    @property
+    def _identifying_params(self) -> dict:
+        return {"goal": self.router.goal}
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Generate a response using Kalibr routing."""
+
+        # Convert LangChain messages to OpenAI format
+        openai_messages = []
+        for m in messages:
+            role = self._get_role(m)
+            openai_messages.append({"role": role, "content": m.content})
+
+        # Add stop sequences if provided
+        if stop:
+            kwargs["stop"] = stop
+
+        # Call router
+        response = self.router.completion(messages=openai_messages, **kwargs)
+
+        # Convert response to LangChain format
+        content = response.choices[0].message.content or ""
+
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(content=content),
+                    generation_info={
+                        "model": response.model,
+                        "finish_reason": response.choices[0].finish_reason,
+                    },
+                )
+            ],
+            llm_output={
+                "model": response.model,
+                "usage": {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                } if hasattr(response, "usage") else {},
+            },
+        )
+
+    def _get_role(self, message: BaseMessage) -> str:
+        """Convert LangChain message type to OpenAI role."""
+        from langchain_core.messages import (
+            HumanMessage,
+            AIMessage,
+            SystemMessage,
+            FunctionMessage,
+            ToolMessage,
+        )
+
+        if isinstance(message, HumanMessage):
+            return "user"
+        elif isinstance(message, AIMessage):
+            return "assistant"
+        elif isinstance(message, SystemMessage):
+            return "system"
+        elif isinstance(message, (FunctionMessage, ToolMessage)):
+            return "function"
+        else:
+            return "user"

--- a/tests/test_langchain_routing.py
+++ b/tests/test_langchain_routing.py
@@ -1,0 +1,122 @@
+"""Tests for LangChain routing integration."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from kalibr.router import Router
+
+
+class TestKalibrChatModel:
+    @patch("kalibr.router.Router._call_openai")
+    def test_basic_generation(self, mock_openai):
+        # Mock OpenAI response
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello!"
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.model = "gpt-4o"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_openai.return_value = mock_response
+
+        router = Router(goal="test", paths=["gpt-4o"], auto_register=False)
+        llm = router.as_langchain()
+
+        from langchain_core.messages import HumanMessage
+        result = llm.invoke([HumanMessage(content="Hi")])
+
+        assert result.content == "Hello!"
+
+    def test_llm_type(self):
+        router = Router(goal="test", paths=["gpt-4o"], auto_register=False)
+        llm = router.as_langchain()
+        assert llm._llm_type == "kalibr"
+
+    def test_identifying_params(self):
+        router = Router(goal="summarize", paths=["gpt-4o"], auto_register=False)
+        llm = router.as_langchain()
+        assert llm._identifying_params == {"goal": "summarize"}
+
+    @patch("kalibr.router.Router._call_openai")
+    def test_message_conversion(self, mock_openai):
+        """Test that LangChain messages are converted to OpenAI format."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Response"
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.model = "gpt-4o"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_openai.return_value = mock_response
+
+        router = Router(goal="test", paths=["gpt-4o"], auto_register=False)
+        llm = router.as_langchain()
+
+        from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
+
+        messages = [
+            SystemMessage(content="You are a helper"),
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there"),
+            HumanMessage(content="How are you?"),
+        ]
+
+        llm.invoke(messages)
+
+        # Verify the call was made with converted messages
+        # Messages are passed as second positional arg to _call_openai(model, messages, tools, **kwargs)
+        call_args = mock_openai.call_args
+        converted_messages = call_args[0][1]
+
+        assert converted_messages[0] == {"role": "system", "content": "You are a helper"}
+        assert converted_messages[1] == {"role": "user", "content": "Hello"}
+        assert converted_messages[2] == {"role": "assistant", "content": "Hi there"}
+        assert converted_messages[3] == {"role": "user", "content": "How are you?"}
+
+    @patch("kalibr.router.Router._call_openai")
+    def test_stop_sequences(self, mock_openai):
+        """Test that stop sequences are passed through."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Response"
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.model = "gpt-4o"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_openai.return_value = mock_response
+
+        router = Router(goal="test", paths=["gpt-4o"], auto_register=False)
+        llm = router.as_langchain()
+
+        from langchain_core.messages import HumanMessage
+
+        llm.invoke([HumanMessage(content="Hi")], stop=["END"])
+
+        call_args = mock_openai.call_args
+        assert call_args[1].get("stop") == ["END"]
+
+    @patch("kalibr.router.Router._call_openai")
+    def test_chat_result_format(self, mock_openai):
+        """Test that the ChatResult is properly formatted."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Generated text"
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.model = "gpt-4o"
+        mock_response.usage.prompt_tokens = 20
+        mock_response.usage.completion_tokens = 10
+        mock_response.usage.total_tokens = 30
+        mock_openai.return_value = mock_response
+
+        router = Router(goal="test", paths=["gpt-4o"], auto_register=False)
+        llm = router.as_langchain()
+
+        from langchain_core.messages import HumanMessage, AIMessage
+
+        result = llm.invoke([HumanMessage(content="Hi")])
+
+        assert result.content == "Generated text"
+        assert isinstance(result, AIMessage)


### PR DESCRIPTION
Add KalibrChatModel that enables using Kalibr's intelligent routing within LangChain pipelines. The chat model converts LangChain messages to OpenAI format and uses the Router class for model selection.