### PR TITLE
Add environment variable validation to Router initialization

### DIFF
--- a/kalibr/router.py
+++ b/kalibr/router.py
@@ -112,6 +112,25 @@ class Router:
             auto_register: If True, register paths on init
         """
         self.goal = goal
+
+        # Validate required environment variables
+        api_key = os.environ.get('KALIBR_API_KEY')
+        tenant_id = os.environ.get('KALIBR_TENANT_ID')
+
+        if not api_key:
+            raise ValueError(
+                "KALIBR_API_KEY environment variable not set.\n"
+                "Get your API key from: https://dashboard.kalibr.systems/settings\n"
+                "Then run: export KALIBR_API_KEY=your-key-here"
+            )
+
+        if not tenant_id:
+            raise ValueError(
+                "KALIBR_TENANT_ID environment variable not set.\n"
+                "Find your Tenant ID at: https://dashboard.kalibr.systems/settings\n"
+                "Then run: export KALIBR_TENANT_ID=your-tenant-id"
+            )
+
         self.success_when = success_when
         self.exploration_rate = exploration_rate
         self._last_trace_id: Optional[str] = None


### PR DESCRIPTION
## Summary
Added validation for required environment variables (`KALIBR_API_KEY` and `KALIBR_TENANT_ID`) during Router initialization to fail fast with helpful error messages if credentials are missing.

## Changes
- Added environment variable validation in `Router.__init__()` that checks for `KALIBR_API_KEY` and `KALIBR_TENANT_ID`
- Raises `ValueError` with descriptive error messages if either variable is not set
- Error messages include helpful guidance on where to find credentials and how to set them

## Implementation Details
- Validation occurs early in the initialization process, before other setup
- Error messages direct users to the dashboard settings page and provide example export commands
- This prevents cryptic failures later when the API key or tenant ID is actually needed