### PR TITLE
Add setup instructions and update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Adaptive routing for AI agents. Kalibr learns which models work best for your ta
 pip install kalibr
 ```
 
+## Setup
+
+Get your credentials from [dashboard.kalibr.systems/settings](https://dashboard.kalibr.systems/settings), then:
+```bash
+export KALIBR_API_KEY=your-api-key
+export KALIBR_TENANT_ID=your-tenant-id
+export OPENAI_API_KEY=sk-...  # or ANTHROPIC_API_KEY for Claude models
+```
+
 ## Quick Start
 ```python
 from kalibr import Router
@@ -215,6 +224,6 @@ Apache-2.0
 
 ## Links
 
-- [Docs](https://kalibr.dev/docs)
+- [Docs](https://kalibr.systems/docs)
 - [Dashboard](https://dashboard.kalibr.systems)
 - [GitHub](https://github.com/kalibr-ai/kalibr-sdk-python)


### PR DESCRIPTION
## Summary
This PR improves the README by adding a dedicated Setup section with credential configuration instructions and updates the documentation URL to the correct domain.

## Changes
- **Added Setup section** with clear instructions for obtaining and configuring API credentials:
  - KALIBR_API_KEY and KALIBR_TENANT_ID from the dashboard
  - Support for both OpenAI and Anthropic API keys
- **Updated documentation link** from `kalibr.dev/docs` to `kalibr.systems/docs` to reflect the correct domain

## Details
The new Setup section is positioned between Installation and Quick Start, making it easy for users to configure their environment before running code examples. The section references the dashboard settings page where users can retrieve their credentials, improving the onboarding experience.