### PR TITLE
Add method aliases and helpful error messages for Router

### DIFF
--- a/kalibr/router.py
+++ b/kalibr/router.py
@@ -335,6 +335,9 @@ class Router:
             self._outcome_reported = True  # Prevent double-reporting on raise
             raise last_exception
 
+    # Alias for common naming confusion
+    complete = completion
+
     def report(
         self,
         success: bool,
@@ -546,6 +549,20 @@ class Router:
                 total_tokens=getattr(response, "usage_metadata", {}).get("total_token_count", 0),
             ),
         )
+
+    def __getattr__(self, name):
+        suggestions = {
+            "predict": "completion",
+            "generate": "completion",
+            "chat": "completion",
+            "invoke": "completion",
+            "run": "completion",
+        }
+        if name in suggestions:
+            raise AttributeError(
+                f"Router has no method '{name}'. Did you mean '{suggestions[name]}()'?"
+            )
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def as_langchain(self):
         """Return a LangChain-compatible chat model."""


### PR DESCRIPTION
## Summary
This PR improves the developer experience of the Router class by adding method aliases and providing helpful error messages when users attempt to call common alternative method names.

## Key Changes
- Added `complete` as an alias for the `completion()` method to handle common naming confusion
- Implemented `__getattr__()` magic method to intercept calls to common alternative method names (`predict`, `generate`, `chat`, `invoke`, `run`) and provide helpful suggestions pointing users to the correct `completion()` method
- Fallback to standard AttributeError for truly unknown attributes

## Implementation Details
The `__getattr__()` method is only invoked when normal attribute lookup fails, making it an efficient way to handle these edge cases without impacting normal method calls. The error messages are user-friendly and guide developers toward the correct API, reducing confusion when migrating from other libraries or frameworks.

https://claude.ai/code/session_01SmV188E7Bwmj5id4C5nD4h