### PR TITLE
Add KalibrResponse wrapper for convenient response access

### DIFF
--- a/kalibr/__init__.py
+++ b/kalibr/__init__.py
@@ -95,7 +95,7 @@ from .intelligence import (
     get_insights,
     FAILURE_CATEGORIES,
 )
-from .router import Router
+from .router import KalibrResponse, Router
 
 if os.getenv("KALIBR_AUTO_INSTRUMENT", "true").lower() == "true":
     # Setup OpenTelemetry collector
@@ -170,5 +170,6 @@ __all__ = [
     "update_outcome",
     "get_insights",
     "FAILURE_CATEGORIES",
+    "KalibrResponse",
     "Router",
 ]

--- a/kalibr/router.py
+++ b/kalibr/router.py
@@ -45,6 +45,28 @@ def _create_context_with_trace_id(trace_id_hex: str) -> Optional[Context]:
         return None
 
 
+class KalibrResponse:
+    """Thin wrapper adding convenience properties to ChatCompletion."""
+
+    def __init__(self, response):
+        self._response = response
+
+    @property
+    def content(self):
+        """Shortcut for response.choices[0].message.content"""
+        return self._response.choices[0].message.content
+
+    @property
+    def model(self):
+        return self._response.model
+
+    def __getattr__(self, name):
+        return getattr(self._response, name)
+
+    def __repr__(self):
+        return repr(self._response)
+
+
 class Router:
     """
     Routes LLM requests to the best model based on learned outcomes.
@@ -306,7 +328,7 @@ class Router:
 
                     # Add trace_id to response for explicit linkage
                     response.kalibr_trace_id = trace_id
-                    return response
+                    return KalibrResponse(response)
 
                 except Exception as e:
                     last_exception = e


### PR DESCRIPTION
## Summary
Introduces a `KalibrResponse` wrapper class that provides convenient property access to ChatCompletion responses while maintaining full backward compatibility with the underlying response object.

## Key Changes
- **New `KalibrResponse` class**: A thin wrapper around ChatCompletion responses that adds convenience properties:
  - `content` property: Shortcut for `response.choices[0].message.content`
  - `model` property: Direct access to the model name
  - `__getattr__` delegation: Transparently forwards attribute access to the underlying response for full compatibility
  - `__repr__` override: Maintains readable string representation

- **Updated `Router.completion()` method**: Now wraps the returned response in `KalibrResponse` before returning to callers

- **Export updates**: Added `KalibrResponse` to the public API exports in `__init__.py`

## Implementation Details
The wrapper uses `__getattr__` to delegate all attribute access to the underlying response object, ensuring that any code expecting the original ChatCompletion response will continue to work without modification. This provides a non-breaking way to enhance the response interface with commonly-used shortcuts.

https://claude.ai/code/session_01DWvNvVK4zX1mxz2rjbreCJ