### PR TITLE
Add provisioning token auto-exchange for API key resolution

### DIFF
--- a/kalibr/collector.py
+++ b/kalibr/collector.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 import requests
 
+from kalibr.provision import resolve_credentials
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -109,8 +110,8 @@ class KalibrHTTPSpanExporter(SpanExporter):
             tenant_id: Tenant ID (default: from KALIBR_TENANT_ID env var)
         """
         self.url = url or os.getenv("KALIBR_COLLECTOR_URL", self.DEFAULT_URL)
-        self.api_key = api_key or os.getenv("KALIBR_API_KEY")
-        self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "default")
+        self.api_key, resolved_tenant = resolve_credentials(api_key, tenant_id)
+        self.tenant_id = resolved_tenant or "default"
         self.environment = os.getenv("KALIBR_ENVIRONMENT", "production")
 
     def export(self, spans) -> SpanExportResult:

--- a/kalibr/intelligence.py
+++ b/kalibr/intelligence.py
@@ -38,6 +38,8 @@ from typing import Any, Optional
 
 import httpx
 
+from kalibr.provision import resolve_credentials
+
 # Default intelligence API endpoint
 DEFAULT_INTELLIGENCE_URL = "https://kalibr-intelligence.fly.dev"
 
@@ -68,8 +70,9 @@ class KalibrIntelligence:
         base_url: str | None = None,
         timeout: float = 10.0,
     ):
-        self.api_key = api_key or os.getenv("KALIBR_API_KEY", "")
-        self.tenant_id = tenant_id or os.getenv("KALIBR_TENANT_ID", "")
+        self.api_key, resolved_tenant = resolve_credentials(api_key, tenant_id)
+        self.api_key = self.api_key or ""
+        self.tenant_id = resolved_tenant or ""
         self.base_url = (
             base_url
             or os.getenv("KALIBR_INTELLIGENCE_URL", DEFAULT_INTELLIGENCE_URL)

--- a/kalibr/provision.py
+++ b/kalibr/provision.py
@@ -1,0 +1,72 @@
+"""Auto-exchange a provisioning token for an API key."""
+
+import os
+import socket
+import threading
+from typing import Optional, Tuple
+
+import requests
+
+_lock = threading.Lock()
+_cached_api_key: Optional[str] = None
+_cached_tenant_id: Optional[str] = None
+
+PROVISION_URL = "https://kalibr-backend.fly.dev/api/provisioning/provision"
+
+
+def resolve_credentials(
+    api_key: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Resolve API key and tenant ID.
+
+    Priority: explicit args > env vars > provisioning token exchange.
+
+    Returns (api_key, tenant_id).
+    """
+    global _cached_api_key, _cached_tenant_id
+
+    resolved_key = api_key or os.getenv("KALIBR_API_KEY")
+    resolved_tenant = tenant_id or os.getenv("KALIBR_TENANT_ID")
+
+    if resolved_key:
+        return resolved_key, resolved_tenant
+
+    prov_token = os.getenv("KALIBR_PROVISIONING_TOKEN")
+    if not prov_token:
+        return None, resolved_tenant
+
+    # Use cached result if already exchanged this process lifetime
+    with _lock:
+        if _cached_api_key:
+            return _cached_api_key, _cached_tenant_id
+
+        try:
+            name = os.getenv("KALIBR_AGENT_NAME") or socket.gethostname()
+            response = requests.post(
+                PROVISION_URL,
+                json={
+                    "provisioning_token": prov_token,
+                    "name": name,
+                    "source": "sdk-auto",
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            _cached_api_key = data["api_key"]
+            _cached_tenant_id = data.get("tenant_id", resolved_tenant)
+
+            # Also set env vars so other SDK components pick them up
+            os.environ["KALIBR_API_KEY"] = _cached_api_key
+            if _cached_tenant_id:
+                os.environ["KALIBR_TENANT_ID"] = _cached_tenant_id
+
+            print(f"[Kalibr SDK] Provisioned API key via token (tenant: {_cached_tenant_id})")
+            return _cached_api_key, _cached_tenant_id
+
+        except Exception as e:
+            print(f"[Kalibr SDK] Failed to exchange provisioning token: {e}")
+            return None, resolved_tenant

--- a/kalibr/router.py
+++ b/kalibr/router.py
@@ -7,6 +7,7 @@ import logging
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from kalibr.provision import resolve_credentials
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import SpanContext, TraceFlags, NonRecordingSpan, set_span_in_context
 from opentelemetry.context import Context
@@ -113,22 +114,19 @@ class Router:
         """
         self.goal = goal
 
-        # Validate required environment variables
-        api_key = os.environ.get('KALIBR_API_KEY')
-        tenant_id = os.environ.get('KALIBR_TENANT_ID')
+        # Validate required credentials
+        api_key, tenant_id = resolve_credentials()
 
         if not api_key:
             raise ValueError(
-                "KALIBR_API_KEY environment variable not set.\n"
-                "Get your API key from: https://dashboard.kalibr.systems/settings\n"
-                "Then run: export KALIBR_API_KEY=your-key-here"
+                "No API key found. Set KALIBR_API_KEY or KALIBR_PROVISIONING_TOKEN.\n"
+                "Get your API key from: https://dashboard.kalibr.systems/settings"
             )
 
         if not tenant_id:
             raise ValueError(
                 "KALIBR_TENANT_ID environment variable not set.\n"
-                "Find your Tenant ID at: https://dashboard.kalibr.systems/settings\n"
-                "Then run: export KALIBR_TENANT_ID=your-tenant-id"
+                "Find your Tenant ID at: https://dashboard.kalibr.systems/settings"
             )
 
         self.success_when = success_when


### PR DESCRIPTION
## Summary
This PR introduces automatic provisioning token exchange functionality to simplify credential management in the Kalibr SDK. Instead of requiring users to manually obtain and set API keys, they can now provide a provisioning token that is automatically exchanged for an API key at runtime.

## Key Changes
- **New `provision.py` module**: Implements `resolve_credentials()` function that handles credential resolution with a clear priority order:
  1. Explicitly passed arguments
  2. Environment variables (`KALIBR_API_KEY`, `KALIBR_TENANT_ID`)
  3. Automatic provisioning token exchange via `KALIBR_PROVISIONING_TOKEN`
  
- **Provisioning token exchange**: When a provisioning token is provided, the SDK automatically exchanges it for an API key by making a POST request to the provisioning backend, including the agent name (from `KALIBR_AGENT_NAME` env var or hostname)

- **Caching mechanism**: Exchanged credentials are cached per process lifetime using a thread-safe lock to avoid redundant API calls

- **Updated credential handling across modules**:
  - `router.py`: Uses `resolve_credentials()` instead of direct env var access
  - `intelligence.py`: Integrates provisioning token exchange
  - `collector.py`: Integrates provisioning token exchange

- **Improved error messages**: Updated validation error messages to mention both API key and provisioning token options

## Implementation Details
- Thread-safe caching with `threading.Lock()` to handle concurrent access
- Graceful fallback: If provisioning fails, the function returns `None` for the API key rather than raising an exception
- Environment variables are updated after successful provisioning so other SDK components automatically pick up the credentials
- 10-second timeout on provisioning requests to prevent hanging
- User-friendly logging messages indicate successful provisioning or failures

https://claude.ai/code/session_01LxDJtyJoZXd9PsAbNAnfBC