### PR TITLE
Add HuggingFace InferenceClient instrumentation

### DIFF
--- a/kalibr/instrumentation/huggingface_instr.py
+++ b/kalibr/instrumentation/huggingface_instr.py
@@ -1,0 +1,414 @@
+"""
+HuggingFace InferenceClient Instrumentation
+
+Monkey-patches the huggingface_hub InferenceClient and AsyncInferenceClient
+to automatically emit OpenTelemetry spans for all task-specific API calls.
+
+Covers text, audio, image, embedding, and classification tasks via a single
+instrumentor, since all go through the same InferenceClient SDK.
+
+Thread-safe singleton pattern using double-checked locking.
+"""
+
+import threading
+import time
+from functools import wraps
+from typing import Any, Dict, Optional
+
+from opentelemetry.trace import SpanKind
+
+from .base import BaseCostAdapter, BaseInstrumentation
+
+
+# Task type to modality mapping
+TASK_MODALITY = {
+    "chat_completion": "text",
+    "text_generation": "text",
+    "translation": "text",
+    "summarization": "text",
+    "automatic_speech_recognition": "audio",
+    "text_to_speech": "audio",
+    "text_to_image": "image",
+    "feature_extraction": "embedding",
+    "text_classification": "classification",
+}
+
+# Methods to patch on InferenceClient / AsyncInferenceClient
+PATCHED_METHODS = [
+    "chat_completion",
+    "text_generation",
+    "automatic_speech_recognition",
+    "text_to_speech",
+    "text_to_image",
+    "feature_extraction",
+    "text_classification",
+    "translation",
+    "summarization",
+]
+
+
+def _extract_metrics(task: str, response: Any) -> dict:
+    """Extract task-appropriate usage metrics from a HuggingFace response.
+
+    Args:
+        task: The task name (e.g. "chat_completion", "text_to_image")
+        response: The raw response object from the InferenceClient
+
+    Returns:
+        Dictionary of usage metrics appropriate for the task type.
+    """
+    metrics: dict = {}
+
+    if task in ("chat_completion",):
+        # ChatCompletionOutput has .usage with .prompt_tokens / .completion_tokens
+        if hasattr(response, "usage") and response.usage:
+            usage = response.usage
+            metrics["input_tokens"] = getattr(usage, "prompt_tokens", 0) or 0
+            metrics["output_tokens"] = getattr(usage, "completion_tokens", 0) or 0
+        elif isinstance(response, dict):
+            usage = response.get("usage", {})
+            metrics["input_tokens"] = usage.get("prompt_tokens", 0)
+            metrics["output_tokens"] = usage.get("completion_tokens", 0)
+
+    elif task in ("text_generation", "translation", "summarization"):
+        # TextGenerationOutput may carry token counts in .details
+        if hasattr(response, "details") and response.details:
+            details = response.details
+            metrics["input_tokens"] = getattr(details, "prefill_tokens", 0) or 0
+            metrics["output_tokens"] = getattr(details, "generated_tokens", 0) or 0
+        elif isinstance(response, dict):
+            details = response.get("details", {}) or {}
+            metrics["input_tokens"] = details.get("prefill_tokens", 0)
+            metrics["output_tokens"] = details.get("generated_tokens", 0)
+
+    elif task == "automatic_speech_recognition":
+        # ASR output may include duration metadata
+        if isinstance(response, dict):
+            metrics["audio_duration_ms"] = response.get("audio_duration_ms", 0)
+        elif hasattr(response, "audio_duration_ms"):
+            metrics["audio_duration_ms"] = response.audio_duration_ms or 0
+        # Fallback: check for chunks with timestamps
+        if not metrics.get("audio_duration_ms"):
+            chunks = None
+            if hasattr(response, "chunks"):
+                chunks = response.chunks
+            elif isinstance(response, dict):
+                chunks = response.get("chunks")
+            if chunks and len(chunks) > 0:
+                last = chunks[-1]
+                ts = getattr(last, "timestamp", None) or (
+                    last.get("timestamp") if isinstance(last, dict) else None
+                )
+                if ts and len(ts) >= 2:
+                    metrics["audio_duration_ms"] = int(ts[1] * 1000)
+
+    elif task == "text_to_speech":
+        if isinstance(response, bytes):
+            metrics["audio_bytes"] = len(response)
+        if hasattr(response, "audio_duration_ms"):
+            metrics["audio_duration_ms"] = response.audio_duration_ms or 0
+
+    elif task == "text_to_image":
+        metrics["image_count"] = 1
+        if hasattr(response, "size"):
+            w, h = response.size
+            metrics["image_resolution"] = f"{w}x{h}"
+        elif hasattr(response, "width") and hasattr(response, "height"):
+            metrics["image_resolution"] = f"{response.width}x{response.height}"
+
+    elif task == "feature_extraction":
+        # Embedding result is typically a list of floats or nested list
+        if isinstance(response, list):
+            if len(response) > 0 and isinstance(response[0], list):
+                metrics["vector_dimensions"] = len(response[0])
+            elif len(response) > 0 and isinstance(response[0], (int, float)):
+                metrics["vector_dimensions"] = len(response)
+
+    elif task == "text_classification":
+        if isinstance(response, list) and len(response) > 0:
+            metrics["label_count"] = len(response)
+
+    return metrics
+
+
+class HuggingFaceCostAdapter(BaseCostAdapter):
+    """Cost calculation adapter for HuggingFace models.
+
+    Extends BaseCostAdapter with flexible cost computation that handles
+    multiple modalities (text tokens, audio duration, image generation).
+    Uses centralized pricing from kalibr.pricing module.
+    """
+
+    def get_vendor_name(self) -> str:
+        return "huggingface"
+
+    def calculate_cost(self, model: str, usage: Dict[str, int]) -> float:
+        """Calculate cost in USD for a HuggingFace API call.
+
+        For token-based tasks, uses centralized per-token pricing.
+        For other modalities, returns 0.0 (HuggingFace Inference API
+        pricing varies by deployment; token-based is the common case).
+
+        Args:
+            model: Model identifier (e.g. "meta-llama/Llama-3-8B-Instruct")
+            usage: Usage dict with input_tokens/output_tokens or other metrics
+
+        Returns:
+            Cost in USD (rounded to 6 decimal places)
+        """
+        return self.compute_cost_flexible(model, usage)
+
+    def compute_cost_flexible(self, model: str, usage: Dict[str, Any]) -> float:
+        """Compute cost for any modality using flexible usage metrics.
+
+        Args:
+            model: Model identifier
+            usage: Dict that may contain token counts, audio duration, etc.
+
+        Returns:
+            Cost in USD (rounded to 6 decimal places)
+        """
+        input_tokens = usage.get("input_tokens", 0)
+        output_tokens = usage.get("output_tokens", 0)
+
+        if input_tokens or output_tokens:
+            pricing = self.get_pricing_for_model(model)
+            input_cost = (input_tokens / 1_000_000) * pricing["input"]
+            output_cost = (output_tokens / 1_000_000) * pricing["output"]
+            return round(input_cost + output_cost, 6)
+
+        # Non-token modalities: HuggingFace Inference API pricing is
+        # deployment-dependent. Return 0 rather than guess.
+        return 0.0
+
+    def get_usage_metrics(self, task: str, response: Any) -> dict:
+        """Extract usage metrics from a response based on task type.
+
+        Convenience method wrapping the module-level _extract_metrics.
+
+        Args:
+            task: Task name (e.g. "chat_completion")
+            response: Raw response from InferenceClient
+
+        Returns:
+            Dict of usage metrics
+        """
+        return _extract_metrics(task, response)
+
+
+class HuggingFaceInstrumentation(BaseInstrumentation):
+    """Instrumentation for HuggingFace InferenceClient SDK"""
+
+    def __init__(self):
+        super().__init__("kalibr.huggingface")
+        self._originals: Dict[str, Any] = {}
+        self._async_originals: Dict[str, Any] = {}
+        self.cost_adapter = HuggingFaceCostAdapter()
+
+    def instrument(self) -> bool:
+        """Apply monkey-patching to HuggingFace InferenceClient"""
+        if self._is_instrumented:
+            return True
+
+        try:
+            from huggingface_hub import InferenceClient
+
+            # Patch sync methods
+            for method_name in PATCHED_METHODS:
+                if hasattr(InferenceClient, method_name):
+                    original = getattr(InferenceClient, method_name)
+                    self._originals[method_name] = original
+                    setattr(
+                        InferenceClient,
+                        method_name,
+                        self._traced_wrapper(original, method_name),
+                    )
+
+            # Patch async methods
+            try:
+                from huggingface_hub import AsyncInferenceClient
+
+                for method_name in PATCHED_METHODS:
+                    if hasattr(AsyncInferenceClient, method_name):
+                        original = getattr(AsyncInferenceClient, method_name)
+                        self._async_originals[method_name] = original
+                        setattr(
+                            AsyncInferenceClient,
+                            method_name,
+                            self._traced_async_wrapper(original, method_name),
+                        )
+            except ImportError:
+                pass  # AsyncInferenceClient may not be available
+
+            self._is_instrumented = True
+            return True
+
+        except ImportError:
+            print("⚠️  huggingface_hub not installed, skipping instrumentation")
+            return False
+        except Exception as e:
+            print(f"❌ Failed to instrument HuggingFace SDK: {e}")
+            return False
+
+    def uninstrument(self) -> bool:
+        """Remove monkey-patching from HuggingFace InferenceClient"""
+        if not self._is_instrumented:
+            return True
+
+        try:
+            from huggingface_hub import InferenceClient
+
+            for method_name, original in self._originals.items():
+                setattr(InferenceClient, method_name, original)
+            self._originals.clear()
+
+            try:
+                from huggingface_hub import AsyncInferenceClient
+
+                for method_name, original in self._async_originals.items():
+                    setattr(AsyncInferenceClient, method_name, original)
+                self._async_originals.clear()
+            except ImportError:
+                pass
+
+            self._is_instrumented = False
+            return True
+
+        except Exception as e:
+            print(f"❌ Failed to uninstrument HuggingFace SDK: {e}")
+            return False
+
+    def _traced_wrapper(self, original_func, task_name: str):
+        """Create a sync wrapper that traces a task method."""
+
+        @wraps(original_func)
+        def wrapper(client_self, *args, **kwargs):
+            model = kwargs.get("model", getattr(client_self, "model", None) or "unknown")
+            modality = TASK_MODALITY.get(task_name, "unknown")
+
+            with self.tracer.start_as_current_span(
+                f"huggingface.{task_name}",
+                kind=SpanKind.CLIENT,
+                attributes={
+                    "llm.vendor": "huggingface",
+                    "llm.request.model": str(model),
+                    "llm.system": "huggingface",
+                    "kalibr.modality": modality,
+                    "kalibr.task_type": task_name,
+                },
+            ) as span:
+                start_time = time.time()
+
+                try:
+                    from kalibr.context import inject_kalibr_context_into_span
+
+                    inject_kalibr_context_into_span(span)
+                except Exception:
+                    pass
+
+                try:
+                    result = original_func(client_self, *args, **kwargs)
+                    self._set_response_attributes(span, task_name, model, result, start_time)
+                    return result
+                except Exception as e:
+                    self.set_error(span, e)
+                    raise
+
+        return wrapper
+
+    def _traced_async_wrapper(self, original_func, task_name: str):
+        """Create an async wrapper that traces a task method."""
+
+        @wraps(original_func)
+        async def wrapper(client_self, *args, **kwargs):
+            model = kwargs.get("model", getattr(client_self, "model", None) or "unknown")
+            modality = TASK_MODALITY.get(task_name, "unknown")
+
+            with self.tracer.start_as_current_span(
+                f"huggingface.{task_name}",
+                kind=SpanKind.CLIENT,
+                attributes={
+                    "llm.vendor": "huggingface",
+                    "llm.request.model": str(model),
+                    "llm.system": "huggingface",
+                    "kalibr.modality": modality,
+                    "kalibr.task_type": task_name,
+                },
+            ) as span:
+                start_time = time.time()
+
+                try:
+                    from kalibr.context import inject_kalibr_context_into_span
+
+                    inject_kalibr_context_into_span(span)
+                except Exception:
+                    pass
+
+                try:
+                    result = await original_func(client_self, *args, **kwargs)
+                    self._set_response_attributes(span, task_name, model, result, start_time)
+                    return result
+                except Exception as e:
+                    self.set_error(span, e)
+                    raise
+
+        return wrapper
+
+    def _set_response_attributes(
+        self, span, task_name: str, model: Any, result: Any, start_time: float
+    ) -> None:
+        """Extract metadata from response and set span attributes."""
+        try:
+            # Response model (some responses carry the model used)
+            if hasattr(result, "model"):
+                span.set_attribute("llm.response.model", str(result.model))
+
+            # Latency
+            latency_ms = (time.time() - start_time) * 1000
+            span.set_attribute("llm.latency_ms", round(latency_ms, 2))
+
+            # Task-specific usage metrics
+            metrics = self.cost_adapter.get_usage_metrics(task_name, result)
+
+            # Set metric attributes on span
+            for key, value in metrics.items():
+                span.set_attribute(f"llm.usage.{key}", value)
+
+            # Calculate cost
+            cost = self.cost_adapter.compute_cost_flexible(str(model), metrics)
+            span.set_attribute("llm.cost_usd", cost)
+
+            # Response ID
+            if hasattr(result, "id"):
+                span.set_attribute("llm.response.id", result.id)
+
+        except Exception as e:
+            span.set_attribute("llm.metadata_extraction_error", str(e))
+
+
+# Singleton instance
+_huggingface_instrumentation = None
+_huggingface_lock = threading.Lock()
+
+
+def get_instrumentation() -> HuggingFaceInstrumentation:
+    """Get or create the HuggingFace instrumentation singleton.
+
+    Thread-safe singleton pattern using double-checked locking.
+    """
+    global _huggingface_instrumentation
+    if _huggingface_instrumentation is None:
+        with _huggingface_lock:
+            if _huggingface_instrumentation is None:
+                _huggingface_instrumentation = HuggingFaceInstrumentation()
+    return _huggingface_instrumentation
+
+
+def instrument() -> bool:
+    """Instrument HuggingFace SDK"""
+    return get_instrumentation().instrument()
+
+
+def uninstrument() -> bool:
+    """Uninstrument HuggingFace SDK"""
+    return get_instrumentation().uninstrument()

--- a/kalibr/instrumentation/registry.py
+++ b/kalibr/instrumentation/registry.py
@@ -35,7 +35,7 @@ def auto_instrument(providers: List[str] = None) -> Dict[str, bool]:
 
     # Default to all providers if none specified
     if providers is None:
-        providers = ["openai", "anthropic", "google", "openai_responses"]
+        providers = ["openai", "anthropic", "google", "openai_responses", "huggingface"]
 
     results = {}
 
@@ -88,6 +88,16 @@ def auto_instrument(providers: List[str] = None) -> Dict[str, bool]:
                     with _registry_lock:
                         _instrumented_providers.add(provider_lower)
                     print(f"✅ Instrumented OpenAI Responses API")
+
+            elif provider_lower == "huggingface":
+                from . import huggingface_instr
+
+                success = huggingface_instr.instrument()
+                results[provider_lower] = success
+                if success:
+                    with _registry_lock:
+                        _instrumented_providers.add(provider_lower)
+                    print(f"✅ Instrumented HuggingFace SDK")
 
             else:
                 print(f"⚠️  Unknown provider: {provider}")
@@ -161,6 +171,16 @@ def uninstrument_all() -> Dict[str, bool]:
                     with _registry_lock:
                         _instrumented_providers.discard(provider)
                     print(f"✅ Uninstrumented OpenAI Responses API")
+
+            elif provider == "huggingface":
+                from . import huggingface_instr
+
+                success = huggingface_instr.uninstrument()
+                results[provider] = success
+                if success:
+                    with _registry_lock:
+                        _instrumented_providers.discard(provider)
+                    print(f"✅ Uninstrumented HuggingFace SDK")
 
         except Exception as e:
             print(f"❌ Failed to uninstrument {provider}: {e}")

--- a/kalibr/pricing.py
+++ b/kalibr/pricing.py
@@ -48,6 +48,18 @@ MODEL_PRICING: Dict[str, Dict[str, Dict[str, float]]] = {
         "claude-2.0": {"input": 8.00, "output": 24.00},
         "claude-instant-1.2": {"input": 0.80, "output": 2.40},
     },
+    "huggingface": {
+        # Meta Llama models (HuggingFace Inference API pricing)
+        "meta-llama/llama-3-70b-instruct": {"input": 0.90, "output": 0.90},
+        "meta-llama/llama-3-8b-instruct": {"input": 0.20, "output": 0.20},
+        "meta-llama/llama-3.1-405b-instruct": {"input": 5.00, "output": 15.00},
+        "meta-llama/llama-3.1-70b-instruct": {"input": 0.90, "output": 0.90},
+        "meta-llama/llama-3.1-8b-instruct": {"input": 0.20, "output": 0.20},
+        # Mistral models
+        "mistralai/mistral-7b-instruct-v0.3": {"input": 0.20, "output": 0.20},
+        "mistralai/mixtral-8x7b-instruct-v0.1": {"input": 0.60, "output": 0.60},
+        # Default fallback for unknown HuggingFace models
+    },
     "google": {
         # Gemini 2.5 models
         "gemini-2.5-pro": {"input": 1.25, "output": 5.00},
@@ -70,6 +82,7 @@ DEFAULT_PRICING: Dict[str, Dict[str, float]] = {
     "openai": {"input": 30.00, "output": 60.00},  # GPT-4 pricing
     "anthropic": {"input": 15.00, "output": 75.00},  # Claude 3 Opus pricing
     "google": {"input": 1.25, "output": 5.00},  # Gemini 1.5 Pro pricing
+    "huggingface": {"input": 1.00, "output": 1.00},  # Conservative default
 }
 
 

--- a/tests/test_huggingface_instrumentation.py
+++ b/tests/test_huggingface_instrumentation.py
@@ -1,0 +1,530 @@
+"""
+Unit tests for HuggingFace InferenceClient instrumentation
+
+Tests:
+1. Instrumentation can be applied and removed (patches/restores methods)
+2. Instrumented SDK calls create spans with correct attributes
+3. Cost calculation uses flexible adapter
+4. Modality and task_type attributes are set correctly on spans
+5. Metric extraction works for different task types
+"""
+
+import pytest
+import sys
+import os
+import types
+from unittest.mock import Mock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+
+class InMemorySpanExporter(SpanExporter):
+    """In-memory span exporter for testing"""
+
+    def __init__(self):
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self):
+        pass
+
+    def clear(self):
+        self.spans.clear()
+
+
+@pytest.fixture(autouse=False)
+def tracer_provider():
+    """Setup tracer provider with in-memory exporter.
+
+    Forces the global TracerProvider so spans are captured in-memory.
+    """
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(processor)
+    # Force-set the global provider (bypasses "already set" guard)
+    trace._TRACER_PROVIDER = None  # reset so set works
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    trace.set_tracer_provider(provider)
+
+    yield provider, exporter
+
+    provider.shutdown()
+    exporter.clear()
+
+
+def _make_mock_inference_client():
+    """Create a mock huggingface_hub module with InferenceClient and AsyncInferenceClient."""
+    mock_module = types.ModuleType("huggingface_hub")
+
+    class MockInferenceClient:
+        def __init__(self, model=None, **kwargs):
+            self.model = model
+
+        def chat_completion(self, messages=None, model=None, **kwargs):
+            return Mock()
+
+        def text_generation(self, prompt=None, model=None, **kwargs):
+            return Mock()
+
+        def automatic_speech_recognition(self, audio=None, model=None, **kwargs):
+            return Mock()
+
+        def text_to_speech(self, text=None, model=None, **kwargs):
+            return b"audio-bytes"
+
+        def text_to_image(self, prompt=None, model=None, **kwargs):
+            return Mock()
+
+        def feature_extraction(self, text=None, model=None, **kwargs):
+            return [[0.1, 0.2, 0.3]]
+
+        def text_classification(self, text=None, model=None, **kwargs):
+            return [{"label": "POSITIVE", "score": 0.95}]
+
+        def translation(self, text=None, model=None, **kwargs):
+            return Mock()
+
+        def summarization(self, text=None, model=None, **kwargs):
+            return Mock()
+
+    class MockAsyncInferenceClient:
+        def __init__(self, model=None, **kwargs):
+            self.model = model
+
+        async def chat_completion(self, messages=None, model=None, **kwargs):
+            return Mock()
+
+        async def text_generation(self, prompt=None, model=None, **kwargs):
+            return Mock()
+
+        async def automatic_speech_recognition(self, audio=None, model=None, **kwargs):
+            return Mock()
+
+        async def text_to_speech(self, text=None, model=None, **kwargs):
+            return b"audio-bytes"
+
+        async def text_to_image(self, prompt=None, model=None, **kwargs):
+            return Mock()
+
+        async def feature_extraction(self, text=None, model=None, **kwargs):
+            return [[0.1, 0.2, 0.3]]
+
+        async def text_classification(self, text=None, model=None, **kwargs):
+            return [{"label": "POSITIVE", "score": 0.95}]
+
+        async def translation(self, text=None, model=None, **kwargs):
+            return Mock()
+
+        async def summarization(self, text=None, model=None, **kwargs):
+            return Mock()
+
+    mock_module.InferenceClient = MockInferenceClient
+    mock_module.AsyncInferenceClient = MockAsyncInferenceClient
+    return mock_module
+
+
+@pytest.fixture
+def mock_huggingface():
+    """Inject mock huggingface_hub into sys.modules for instrumentation."""
+    mock_module = _make_mock_inference_client()
+    original = sys.modules.get("huggingface_hub")
+    sys.modules["huggingface_hub"] = mock_module
+    yield mock_module
+    if original is not None:
+        sys.modules["huggingface_hub"] = original
+    else:
+        sys.modules.pop("huggingface_hub", None)
+
+
+@pytest.fixture
+def fresh_instrumentation(mock_huggingface, request):
+    """Provide a fresh HuggingFaceInstrumentation instance (not singleton).
+
+    If the test also uses tracer_provider, the tracer is re-initialized
+    so it picks up the test's TracerProvider.
+    """
+    from kalibr.instrumentation.huggingface_instr import HuggingFaceInstrumentation
+
+    instr = HuggingFaceInstrumentation()
+    # Re-initialize tracer to pick up any TracerProvider set by fixtures
+    instr.tracer = trace.get_tracer("kalibr.huggingface")
+    yield instr
+    instr.uninstrument()
+
+
+class TestInstrumentPatchesMethods:
+    """Test that instrument() patches methods correctly."""
+
+    def test_instrument_patches_sync_methods(self, mock_huggingface, fresh_instrumentation):
+        InferenceClient = mock_huggingface.InferenceClient
+        originals = {m: getattr(InferenceClient, m) for m in [
+            "chat_completion", "text_generation", "text_to_image",
+            "automatic_speech_recognition", "feature_extraction",
+        ]}
+
+        success = fresh_instrumentation.instrument()
+        assert success is True
+        assert fresh_instrumentation.is_instrumented is True
+
+        for method_name, original in originals.items():
+            assert getattr(InferenceClient, method_name) is not original, (
+                f"{method_name} was not patched"
+            )
+
+    def test_instrument_patches_async_methods(self, mock_huggingface, fresh_instrumentation):
+        AsyncInferenceClient = mock_huggingface.AsyncInferenceClient
+        original_chat = AsyncInferenceClient.chat_completion
+
+        fresh_instrumentation.instrument()
+        assert AsyncInferenceClient.chat_completion is not original_chat
+
+    def test_instrument_is_idempotent(self, mock_huggingface, fresh_instrumentation):
+        assert fresh_instrumentation.instrument() is True
+        assert fresh_instrumentation.instrument() is True
+
+
+class TestUninstrumentRestoresOriginals:
+    """Test that uninstrument() restores original methods."""
+
+    def test_uninstrument_restores_sync_methods(self, mock_huggingface, fresh_instrumentation):
+        InferenceClient = mock_huggingface.InferenceClient
+        original_chat = InferenceClient.chat_completion
+
+        fresh_instrumentation.instrument()
+        assert InferenceClient.chat_completion is not original_chat
+
+        success = fresh_instrumentation.uninstrument()
+        assert success is True
+        assert fresh_instrumentation.is_instrumented is False
+        assert InferenceClient.chat_completion is original_chat
+
+    def test_uninstrument_restores_async_methods(self, mock_huggingface, fresh_instrumentation):
+        AsyncInferenceClient = mock_huggingface.AsyncInferenceClient
+        original_chat = AsyncInferenceClient.chat_completion
+
+        fresh_instrumentation.instrument()
+        fresh_instrumentation.uninstrument()
+        assert AsyncInferenceClient.chat_completion is original_chat
+
+    def test_uninstrument_when_not_instrumented(self, mock_huggingface, fresh_instrumentation):
+        assert fresh_instrumentation.uninstrument() is True
+
+
+class TestSpanCreationChatCompletion:
+    """Test span creation for chat_completion (text task)."""
+
+    def test_chat_completion_creates_span(
+        self, tracer_provider, mock_huggingface, fresh_instrumentation
+    ):
+        provider, exporter = tracer_provider
+
+        # Mock response with usage
+        mock_usage = Mock(prompt_tokens=100, completion_tokens=50)
+        mock_response = Mock(usage=mock_usage, model="meta-llama/Llama-3-8B-Instruct", id="resp-1")
+
+        InferenceClient = mock_huggingface.InferenceClient
+        orig_chat = InferenceClient.chat_completion
+        InferenceClient.chat_completion = lambda self, *a, **kw: mock_response
+
+        fresh_instrumentation.instrument()
+
+        client = InferenceClient(model="meta-llama/Llama-3-8B-Instruct")
+        result = client.chat_completion(
+            messages=[{"role": "user", "content": "Hello"}],
+            model="meta-llama/Llama-3-8B-Instruct",
+        )
+
+        assert len(exporter.spans) == 1
+        span = exporter.spans[0]
+        attrs = dict(span.attributes)
+
+        assert span.name == "huggingface.chat_completion"
+        assert attrs["llm.vendor"] == "huggingface"
+        assert attrs["llm.request.model"] == "meta-llama/Llama-3-8B-Instruct"
+        assert attrs["kalibr.modality"] == "text"
+        assert attrs["kalibr.task_type"] == "chat_completion"
+        assert attrs["llm.usage.input_tokens"] == 100
+        assert attrs["llm.usage.output_tokens"] == 50
+        assert "llm.latency_ms" in attrs
+        assert "llm.cost_usd" in attrs
+
+
+class TestSpanCreationASR:
+    """Test span creation for automatic_speech_recognition (audio task)."""
+
+    def test_asr_creates_span_with_audio_modality(
+        self, tracer_provider, mock_huggingface, fresh_instrumentation
+    ):
+        provider, exporter = tracer_provider
+
+        mock_response = {"text": "hello world", "audio_duration_ms": 5000}
+
+        InferenceClient = mock_huggingface.InferenceClient
+        InferenceClient.automatic_speech_recognition = lambda self, *a, **kw: mock_response
+
+        fresh_instrumentation.instrument()
+
+        client = InferenceClient()
+        result = client.automatic_speech_recognition(
+            audio=b"audio-data", model="openai/whisper-large-v3"
+        )
+
+        assert len(exporter.spans) == 1
+        span = exporter.spans[0]
+        attrs = dict(span.attributes)
+
+        assert span.name == "huggingface.automatic_speech_recognition"
+        assert attrs["kalibr.modality"] == "audio"
+        assert attrs["kalibr.task_type"] == "automatic_speech_recognition"
+        assert attrs["llm.usage.audio_duration_ms"] == 5000
+
+
+class TestSpanCreationTextToImage:
+    """Test span creation for text_to_image (image task)."""
+
+    def test_text_to_image_creates_span(
+        self, tracer_provider, mock_huggingface, fresh_instrumentation
+    ):
+        provider, exporter = tracer_provider
+
+        mock_image = Mock()
+        mock_image.size = (1024, 1024)
+        mock_image.model = None
+        del mock_image.model  # no model attr on PIL images
+        del mock_image.id
+
+        InferenceClient = mock_huggingface.InferenceClient
+        InferenceClient.text_to_image = lambda self, *a, **kw: mock_image
+
+        fresh_instrumentation.instrument()
+
+        client = InferenceClient()
+        result = client.text_to_image(
+            prompt="A cat", model="stabilityai/stable-diffusion-xl-base-1.0"
+        )
+
+        assert len(exporter.spans) == 1
+        span = exporter.spans[0]
+        attrs = dict(span.attributes)
+
+        assert span.name == "huggingface.text_to_image"
+        assert attrs["kalibr.modality"] == "image"
+        assert attrs["kalibr.task_type"] == "text_to_image"
+        assert attrs["llm.usage.image_count"] == 1
+        assert attrs["llm.usage.image_resolution"] == "1024x1024"
+
+
+class TestCostCalculation:
+    """Test that cost calculation uses the flexible adapter."""
+
+    def test_cost_adapter_vendor_name(self):
+        from kalibr.instrumentation.huggingface_instr import HuggingFaceCostAdapter
+
+        adapter = HuggingFaceCostAdapter()
+        assert adapter.get_vendor_name() == "huggingface"
+
+    def test_cost_adapter_token_based(self):
+        from kalibr.instrumentation.huggingface_instr import HuggingFaceCostAdapter
+
+        adapter = HuggingFaceCostAdapter()
+        cost = adapter.compute_cost_flexible(
+            "meta-llama/llama-3-8b-instruct",
+            {"input_tokens": 1000, "output_tokens": 500},
+        )
+        # Should use centralized pricing; cost > 0
+        assert cost >= 0.0
+
+    def test_cost_adapter_non_token_returns_zero(self):
+        from kalibr.instrumentation.huggingface_instr import HuggingFaceCostAdapter
+
+        adapter = HuggingFaceCostAdapter()
+        cost = adapter.compute_cost_flexible(
+            "openai/whisper-large-v3",
+            {"audio_duration_ms": 5000},
+        )
+        assert cost == 0.0
+
+    def test_calculate_cost_delegates_to_flexible(self):
+        from kalibr.instrumentation.huggingface_instr import HuggingFaceCostAdapter
+
+        adapter = HuggingFaceCostAdapter()
+        cost = adapter.calculate_cost(
+            "meta-llama/llama-3-8b-instruct",
+            {"input_tokens": 1000, "output_tokens": 500},
+        )
+        assert cost == adapter.compute_cost_flexible(
+            "meta-llama/llama-3-8b-instruct",
+            {"input_tokens": 1000, "output_tokens": 500},
+        )
+
+
+class TestModalityAndTaskAttributes:
+    """Test that modality and task_type attributes are set correctly on spans."""
+
+    @pytest.mark.parametrize(
+        "method_name,expected_modality,expected_task",
+        [
+            ("chat_completion", "text", "chat_completion"),
+            ("text_generation", "text", "text_generation"),
+            ("translation", "text", "translation"),
+            ("summarization", "text", "summarization"),
+            ("automatic_speech_recognition", "audio", "automatic_speech_recognition"),
+            ("text_to_speech", "audio", "text_to_speech"),
+            ("text_to_image", "image", "text_to_image"),
+            ("feature_extraction", "embedding", "feature_extraction"),
+            ("text_classification", "classification", "text_classification"),
+        ],
+    )
+    def test_modality_and_task_type(
+        self,
+        tracer_provider,
+        mock_huggingface,
+        fresh_instrumentation,
+        method_name,
+        expected_modality,
+        expected_task,
+    ):
+        provider, exporter = tracer_provider
+        fresh_instrumentation.instrument()
+
+        client = mock_huggingface.InferenceClient(model="test-model")
+        method = getattr(client, method_name)
+        method(model="test-model")
+
+        assert len(exporter.spans) >= 1
+        span = exporter.spans[-1]
+        attrs = dict(span.attributes)
+
+        assert attrs["kalibr.modality"] == expected_modality
+        assert attrs["kalibr.task_type"] == expected_task
+        assert span.name == f"huggingface.{expected_task}"
+
+
+class TestExtractMetrics:
+    """Test the _extract_metrics helper."""
+
+    def test_chat_completion_metrics_from_object(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = Mock()
+        response.usage = Mock(prompt_tokens=100, completion_tokens=50)
+        metrics = _extract_metrics("chat_completion", response)
+        assert metrics == {"input_tokens": 100, "output_tokens": 50}
+
+    def test_chat_completion_metrics_from_dict(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = {"usage": {"prompt_tokens": 200, "completion_tokens": 80}}
+        metrics = _extract_metrics("chat_completion", response)
+        assert metrics == {"input_tokens": 200, "output_tokens": 80}
+
+    def test_asr_metrics(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = {"text": "hello", "audio_duration_ms": 3500}
+        metrics = _extract_metrics("automatic_speech_recognition", response)
+        assert metrics["audio_duration_ms"] == 3500
+
+    def test_text_to_image_metrics(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = Mock()
+        response.size = (512, 512)
+        metrics = _extract_metrics("text_to_image", response)
+        assert metrics["image_count"] == 1
+        assert metrics["image_resolution"] == "512x512"
+
+    def test_feature_extraction_metrics(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = [[0.1, 0.2, 0.3, 0.4]]
+        metrics = _extract_metrics("feature_extraction", response)
+        assert metrics["vector_dimensions"] == 4
+
+    def test_text_classification_metrics(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = [{"label": "POS", "score": 0.9}, {"label": "NEG", "score": 0.1}]
+        metrics = _extract_metrics("text_classification", response)
+        assert metrics["label_count"] == 2
+
+    def test_text_to_speech_metrics(self):
+        from kalibr.instrumentation.huggingface_instr import _extract_metrics
+
+        response = b"raw-audio-bytes-here"
+        metrics = _extract_metrics("text_to_speech", response)
+        assert metrics["audio_bytes"] == len(response)
+
+
+class TestSingletonPattern:
+    """Test singleton and module-level functions."""
+
+    def test_singleton_returns_same_instance(self, mock_huggingface):
+        from kalibr.instrumentation.huggingface_instr import get_instrumentation
+
+        instr1 = get_instrumentation()
+        instr2 = get_instrumentation()
+        assert instr1 is instr2
+
+    def test_module_level_instrument(self, mock_huggingface):
+        from kalibr.instrumentation import huggingface_instr
+
+        success = huggingface_instr.instrument()
+        assert success is True
+        huggingface_instr.uninstrument()
+
+    def test_module_level_uninstrument(self, mock_huggingface):
+        from kalibr.instrumentation import huggingface_instr
+
+        huggingface_instr.instrument()
+        success = huggingface_instr.uninstrument()
+        assert success is True
+
+
+class TestRegistryIntegration:
+    """Test that HuggingFace is included in the registry."""
+
+    def test_auto_instrument_includes_huggingface(self, mock_huggingface):
+        from kalibr.instrumentation import auto_instrument
+
+        results = auto_instrument(["huggingface"])
+        assert "huggingface" in results
+        assert results["huggingface"] is True
+
+    def test_auto_instrument_default_includes_huggingface(self, mock_huggingface):
+        from kalibr.instrumentation import auto_instrument
+
+        results = auto_instrument()
+        assert "huggingface" in results
+
+
+class TestImportErrorHandling:
+    """Test graceful handling when huggingface_hub is not installed."""
+
+    def test_instrument_returns_false_without_huggingface(self):
+        from kalibr.instrumentation.huggingface_instr import HuggingFaceInstrumentation
+
+        original = sys.modules.get("huggingface_hub")
+        sys.modules["huggingface_hub"] = None  # Simulate ImportError
+
+        instr = HuggingFaceInstrumentation()
+        try:
+            success = instr.instrument()
+            assert success is False
+        finally:
+            if original is not None:
+                sys.modules["huggingface_hub"] = original
+            else:
+                sys.modules.pop("huggingface_hub", None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
This PR adds comprehensive OpenTelemetry instrumentation for the HuggingFace InferenceClient SDK, enabling automatic span creation and cost tracking for all task types (text, audio, image, embedding, and classification).

## Key Changes

- **New HuggingFace Instrumentation Module** (`kalibr/instrumentation/huggingface_instr.py`)
  - Implements `HuggingFaceInstrumentation` class with monkey-patching of both sync and async InferenceClient methods
  - Covers 9 task types: chat_completion, text_generation, automatic_speech_recognition, text_to_speech, text_to_image, feature_extraction, text_classification, translation, and summarization
  - Thread-safe singleton pattern using double-checked locking

- **Cost Calculation** 
  - `HuggingFaceCostAdapter` extends `BaseCostAdapter` with flexible cost computation
  - Supports token-based pricing via centralized pricing module
  - Handles multiple modalities (text tokens, audio duration, image generation)

- **Metric Extraction**
  - `_extract_metrics()` function intelligently extracts task-appropriate usage metrics from responses
  - Handles diverse response formats (objects with attributes, dictionaries, bytes, lists)
  - Extracts token counts, audio duration, image resolution, vector dimensions, and label counts

- **Span Attributes**
  - Sets `kalibr.modality` (text, audio, image, embedding, classification) and `kalibr.task_type` attributes
  - Captures latency, cost, usage metrics, and response metadata
  - Supports context injection via `inject_kalibr_context_into_span()`

- **Registry Integration**
  - Added "huggingface" to default providers in `auto_instrument()`
  - Integrated into instrumentation registry for automatic discovery

- **Pricing Data**
  - Added HuggingFace model pricing to `kalibr/pricing.py` (Meta Llama models and others)

- **Comprehensive Test Suite** (`tests/test_huggingface_instrumentation.py`)
  - 530 lines of unit tests covering instrumentation lifecycle, span creation, cost calculation, modality/task attributes, metric extraction, singleton pattern, registry integration, and error handling
  - Uses in-memory span exporter and mock HuggingFace SDK for isolated testing

## Notable Implementation Details

- Graceful handling of missing `huggingface_hub` dependency (returns False on instrument)
- Separate handling of sync and async methods with identical tracing logic
- Task-to-modality mapping enables consistent attribute naming across different task types
- Flexible cost computation that returns 0.0 for non-token modalities (HuggingFace Inference API pricing is deployment-dependent)
- Error handling preserves original exceptions while recording error context in spans

https://claude.ai/code/session_012rnNXupFH7iZuMfeP9kMms