### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/kalibr/__init__.py
+++ b/kalibr/__init__.py
@@ -36,7 +36,7 @@ CLI Usage:
     kalibr version                       # Show version
 """
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 # Auto-instrument LLM SDKs on import (can be disabled via env var)
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kalibr"
-version = "1.7.0"
+version = "1.8.0"
 description = "Ship agents that fix themselves. Outcome-aware routing for production AI agents."
 authors = [{name = "Kalibr Team", email = "support@kalibr.systems"}]
 readme = "README.md"


### PR DESCRIPTION
Version bump to 1.8.0 for PyPI release.

## Changes since 1.7.0

**#121 — kalibr init HuggingFace support**
- Scanner detects all 17 HF InferenceClient task methods + pipeline()
- Rewriter generates router.execute() with task-appropriate model pairs
- router.execute() task_method_map covers all 17 PATCHED_METHODS (was 10)
- All scaffolded Routers now include 2 default paths (Thompson Sampling works from day one)
- import kalibr enforced as first line in all generated code

**#123 — HF token + DeepSeek provider**
- HF_API_TOKEN / HUGGING_FACE_HUB_TOKEN passed to InferenceClient
- deepseek-* models routed correctly via _call_deepseek() instead of falling through to OpenAI

**#124 — DeepSeek pricing + vendor attribution**
- DeepSeek added to pricing.py (V3, R1, Coder at correct rates)
- OpenAI instrumentor detects DeepSeek by model prefix, sets correct llm.vendor and cost