### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/kalibr/__init__.py
+++ b/kalibr/__init__.py
@@ -36,7 +36,7 @@ CLI Usage:
     kalibr version                       # Show version
 """
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 # Auto-instrument LLM SDKs on import (can be disabled via env var)
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kalibr"
-version = "1.8.0"
+version = "1.9.0"
 description = "Outcome-aware LLM routing for production AI agents. Routes between models, tools, and parameters based on real success signals using Thompson Sampling. Automatic fallback, cost optimization, and continuous learning — no redeploy required."
 authors = [{name = "Kalibr Team", email = "support@kalibr.systems"}]
 readme = "README.md"


### PR DESCRIPTION
Voice support (ElevenLabs, Deepgram, OpenAI Audio, router.synthesize/transcribe, kalibr_voice) shipped in #112. Bumping to 1.9.0.