### PR TITLE
docs: add self-healing execution loop section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,17 +229,17 @@ No dashboards to watch. No alerts to triage. Your agent improves itself.
 
 ## Self-healing execution loop
 
-Every model call runs through Kalibr's self-contained healing loop:
+Every model call runs through a self-contained healing loop — no orchestrator required:
 
-1. **Meta prompt generation** — Kalibr generates a task-specific system prompt before the call (using your API key)
-2. **Model call** — runs on your API key with the meta prompt
-3. **Gate 1: structural eval** — deterministic check: did the output match the expected format?
-4. **If failure: LLM judge** — classifies whether it's a prompt problem or model problem (using your API key)
-   - Prompt problem → meta prompt is repaired, retry with same model
-   - Model problem → swap to next-best model, retry
+1. **Meta prompt generation** — Kalibr instruments an LLM (your API key) to generate a task-specific system prompt from your goal and request
+2. **Model call** — runs on your API key with the meta prompt as system message
+3. **Gate 1 structural eval** — deterministic: did the output match the expected format?
+4. **If failure: LLM judge** — instruments another LLM (your API key) to classify the failure:
+   - Prompt problem → meta prompt is repaired and retried on the same model
+   - Model problem → swap to next-best model and retry
 5. **Outcome reported** — bandit updates for (model × prompt variant × goal)
 
-No orchestrator required. Your original messages are never modified. All LLM calls for meta prompt generation and repair run on your API keys — zero Kalibr inference cost.
+Your original messages are never modified. All LLM calls for meta prompt generation and repair run on your API keys — zero Kalibr inference cost.
 
 ## Paths
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,20 @@ Every call your agent makes generates data. Kalibr uses that data to get better.
 
 No dashboards to watch. No alerts to triage. Your agent improves itself.
 
+## Self-healing execution loop
+
+Every model call runs through Kalibr's self-contained healing loop:
+
+1. **Meta prompt generation** — Kalibr generates a task-specific system prompt before the call (using your API key)
+2. **Model call** — runs on your API key with the meta prompt
+3. **Gate 1: structural eval** — deterministic check: did the output match the expected format?
+4. **If failure: LLM judge** — classifies whether it's a prompt problem or model problem (using your API key)
+   - Prompt problem → meta prompt is repaired, retry with same model
+   - Model problem → swap to next-best model, retry
+5. **Outcome reported** — bandit updates for (model × prompt variant × goal)
+
+No orchestrator required. Your original messages are never modified. All LLM calls for meta prompt generation and repair run on your API keys — zero Kalibr inference cost.
+
 ## Paths
 
 A path is any combination of model + tools + params. Kalibr tracks each combination separately and learns which one works best for each goal.


### PR DESCRIPTION
Adds a Self-healing execution loop section explaining the meta prompt generation, LLM judge classification, and repair/swap loop. Clarifies that all LLM calls run on user keys — zero Kalibr inference cost.