### PR TITLE
fix(cli): pass provision secret header in agent signup flow

### DIFF
--- a/kalibr/cli/auth_cmd.py
+++ b/kalibr/cli/auth_cmd.py
@@ -55,10 +55,16 @@ def _agent_signup(email: str | None) -> None:
         console.print("  Your human's email address so they can claim the dashboard.")
         raise typer.Exit(1)
 
+    provision_secret = os.environ.get("KALIBR_PROVISION_SECRET", "")
+    headers = {"Content-Type": "application/json"}
+    if provision_secret:
+        headers["X-Provision-Secret"] = provision_secret
+
     try:
         resp = requests.post(
             f"{BACKEND_URL}/api/cli-auth/signup-and-provision",
             json={"agent_name": "kalibr-agent", "human_email": email},
+            headers=headers,
             timeout=15,
         )
     except requests.RequestException as e:

--- a/kalibr/cli/signup_cmd.py
+++ b/kalibr/cli/signup_cmd.py
@@ -19,10 +19,16 @@ def signup(
 
     console.print(f"[bold]Creating Kalibr account for {email}...[/bold]")
 
+    provision_secret = os.environ.get("KALIBR_PROVISION_SECRET", "")
+    headers = {"Content-Type": "application/json"}
+    if provision_secret:
+        headers["X-Provision-Secret"] = provision_secret
+
     try:
         resp = requests.post(
             f"{BACKEND_URL}/api/cli-auth/signup-and-provision",
             json={"human_email": email, "agent_name": agent_name},
+            headers=headers,
             timeout=20,
         )
 


### PR DESCRIPTION
Companion to kalibr-ai/kalibr-app security fix.

Passes `X-Provision-Secret` header (from `KALIBR_PROVISION_SECRET` env var) when calling the signup-and-provision endpoint.