### PR TITLE
feat(gate3): session delta tracking, momentum computation, silence reward handler

### DIFF
--- a/kalibr/__init__.py
+++ b/kalibr/__init__.py
@@ -103,7 +103,7 @@ from .router import Router, TraceHandle
 from .feedback import (
     KalibrFeedback, track_run, user_rejected, user_accepted, get_feedback,
     classify_satisfaction, classify_satisfaction_async, emit_signal,
-    report_pipeline, report_user_turn, report_action,
+    report_pipeline, report_user_turn, report_action, report_session_end,
 )
 
 if os.getenv("KALIBR_AUTO_INSTRUMENT", "true").lower() == "true":
@@ -204,4 +204,5 @@ __all__ = [
     "report_pipeline",
     "report_user_turn",
     "report_action",
+    "report_session_end",
 ]

--- a/kalibr/feedback.py
+++ b/kalibr/feedback.py
@@ -30,6 +30,16 @@ from typing import Optional
 
 logger = logging.getLogger("kalibr.feedback")
 
+_session_locks: dict = {}
+_session_locks_mutex = threading.Lock()
+
+
+def _get_session_lock(session_id: str):
+    with _session_locks_mutex:
+        if session_id not in _session_locks:
+            _session_locks[session_id] = threading.Lock()
+        return _session_locks[session_id]
+
 
 class KalibrFeedback:
     """
@@ -453,8 +463,8 @@ def report_pipeline(
         logger.warning("report_pipeline failed: %s", e)
 
 
-def _bag_of_words_cosine(text1: str, text2: str) -> float:
-    """Simple bag-of-words cosine similarity. No model needed."""
+def _jaccard_similarity(text1: str, text2: str) -> float:
+    """Jaccard similarity between two texts. No model needed."""
     words1 = set(text1.lower().split())
     words2 = set(text2.lower().split())
     if not words1 or not words2:
@@ -471,7 +481,7 @@ _AFFIRM_WORDS = {"thanks", "perfect", "great", "yes", "good", "exactly", "awesom
 def _compute_delta(prev_msg: str, curr_msg: str) -> dict:
     """Compute delta between two consecutive user messages."""
     return {
-        "cosine": _bag_of_words_cosine(prev_msg, curr_msg),
+        "jaccard": _jaccard_similarity(prev_msg, curr_msg),
         "len_ratio": len(curr_msg) / max(len(prev_msg), 1),
         "frust": sum(1 for w in _FRUST_WORDS if w in curr_msg.lower()),
         "affirm": sum(1 for w in _AFFIRM_WORDS if w in curr_msg.lower()),
@@ -488,14 +498,16 @@ def _compute_momentum(deltas: list) -> str:
     if not deltas or len(deltas) < 2:
         return "flat"
     recent = deltas[-4:]
-    avg_cosine = sum(d["cosine"] for d in recent) / len(recent)
+    avg_jaccard = sum(d["jaccard"] for d in recent) / len(recent)
     avg_len = sum(d["len_ratio"] for d in recent) / len(recent)
     total_frust = sum(d["frust"] for d in recent)
     total_affirm = sum(d["affirm"] for d in recent)
 
-    if avg_cosine > 0.70 and avg_len < 1.1 and total_frust == 0:
+    if avg_jaccard > 0.50 and avg_len < 1.1 and total_frust == 0:
         return "closing"
-    if avg_cosine < 0.55 or total_frust > 1 or (avg_len > 1.3 and total_frust >= 1):
+    if total_affirm >= 2 and total_frust == 0 and avg_len < 1.2:
+        return "closing"
+    if avg_jaccard < 0.35 or total_frust > 1 or (avg_len > 1.3 and total_frust >= 1):
         return "widening"
     return "flat"
 
@@ -509,45 +521,47 @@ def report_user_turn(session_id: str, user_message: str) -> None:
     Never blocks the caller.
     """
     try:
-        session = _read_session(session_id)
-        if session is None:
-            return
+        lock = _get_session_lock(session_id)
+        with lock:
+            session = _read_session(session_id)
+            if session is None:
+                return
 
-        # Delta tracking
-        prev_msg = session.get("last_user_message", "")
-        if prev_msg:
-            delta = _compute_delta(prev_msg, user_message)
-            deltas = session.get("deltas", [])
-            deltas.append(delta)
-            if len(deltas) > 8:
-                deltas = deltas[-8:]
-            session["deltas"] = deltas
-            session["momentum"] = _compute_momentum(deltas)
-        session["last_user_message"] = user_message
-        # Persist session with updated delta state
-        _get_session_path(session_id).write_text(json.dumps(session))
+            # Delta tracking
+            prev_msg = session.get("last_user_message", "")
+            if prev_msg:
+                delta = _compute_delta(prev_msg, user_message)
+                deltas = session.get("deltas", [])
+                deltas.append(delta)
+                if len(deltas) > 8:
+                    deltas = deltas[-8:]
+                session["deltas"] = deltas
+                session["momentum"] = _compute_momentum(deltas)
+            session["last_user_message"] = user_message
+            # Persist session with updated delta state
+            _get_session_path(session_id).write_text(json.dumps(session))
 
-        api_key, tenant_id, base_url = _fb_config()
-        if not api_key or not tenant_id:
-            return
+            api_key, tenant_id, base_url = _fb_config()
+            if not api_key or not tenant_id:
+                return
 
-        # Layer 1 — heuristic classifier
-        confidence, signal_type, dimensions = _heuristic_classify(user_message)
+            # Layer 1 — heuristic classifier
+            confidence, signal_type, dimensions = _heuristic_classify(user_message)
 
-        if confidence >= 0.85:
-            _fire_user_turn_signal(
-                base_url, api_key, tenant_id, session, session_id,
-                signal_type, confidence, dimensions, user_message,
-                momentum=session.get("momentum", "flat"),
-            )
-        else:
-            # Fire LLM classifier in background thread
-            t = threading.Thread(
-                target=_llm_classify_and_send,
-                args=(base_url, api_key, tenant_id, session, session_id, user_message),
-                daemon=True,
-            )
-            t.start()
+            if confidence >= 0.85:
+                _fire_user_turn_signal(
+                    base_url, api_key, tenant_id, session, session_id,
+                    signal_type, confidence, dimensions, user_message,
+                    momentum=session.get("momentum", "flat"),
+                )
+            else:
+                # Fire LLM classifier in background thread
+                t = threading.Thread(
+                    target=_llm_classify_and_send,
+                    args=(base_url, api_key, tenant_id, session, session_id, user_message),
+                    daemon=True,
+                )
+                t.start()
     except Exception as e:
         logger.warning("report_user_turn failed: %s", e)
 
@@ -606,7 +620,8 @@ def _fire_user_turn_signal(
         "goal": session.get("goal", ""),
         "session_id": session_id,
         "raw_evidence": raw_evidence[:500],
-        "momentum": momentum,
+        # TODO: re-enable once API schema accepts momentum field
+        # "momentum": momentum,
     }
     if dimensions:
         payload["dimensions"] = dimensions
@@ -664,9 +679,16 @@ def _llm_classify_and_send(base_url, api_key, tenant_id, session, session_id, us
         confidence = float(result.get("confidence", 0.5))
         dimensions = result.get("dimensions", [])
 
+        try:
+            s = _read_session(session_id)
+            cur_momentum = s.get("momentum", "flat") if s else "flat"
+        except Exception:
+            cur_momentum = "flat"
+
         _fire_user_turn_signal(
             base_url, api_key, tenant_id, session, session_id,
             signal_type, confidence, dimensions, user_message,
+            momentum=cur_momentum,
         )
     except Exception as e:
         logger.warning("LLM classify failed: %s", e)

--- a/kalibr/feedback.py
+++ b/kalibr/feedback.py
@@ -428,6 +428,9 @@ def report_pipeline(
             "model": model,
             "meta_prompt_id": meta_prompt_id,
             "ts": time.time(),
+            "deltas": [],
+            "momentum": "flat",
+            "last_user_message": "",
         }
         _get_session_path(session_id).write_text(json.dumps(session_data))
 
@@ -450,6 +453,53 @@ def report_pipeline(
         logger.warning("report_pipeline failed: %s", e)
 
 
+def _bag_of_words_cosine(text1: str, text2: str) -> float:
+    """Simple bag-of-words cosine similarity. No model needed."""
+    words1 = set(text1.lower().split())
+    words2 = set(text2.lower().split())
+    if not words1 or not words2:
+        return 0.5
+    intersection = len(words1 & words2)
+    union = len(words1 | words2)
+    return intersection / union if union > 0 else 0.5
+
+
+_FRUST_WORDS = {"again", "wrong", "bad", "no", "fix", "redo", "useless", "terrible", "horrible", "stop", "different", "change", "not what"}
+_AFFIRM_WORDS = {"thanks", "perfect", "great", "yes", "good", "exactly", "awesome", "love", "correct", "nice"}
+
+
+def _compute_delta(prev_msg: str, curr_msg: str) -> dict:
+    """Compute delta between two consecutive user messages."""
+    return {
+        "cosine": _bag_of_words_cosine(prev_msg, curr_msg),
+        "len_ratio": len(curr_msg) / max(len(prev_msg), 1),
+        "frust": sum(1 for w in _FRUST_WORDS if w in curr_msg.lower()),
+        "affirm": sum(1 for w in _AFFIRM_WORDS if w in curr_msg.lower()),
+    }
+
+
+def _compute_momentum(deltas: list) -> str:
+    """
+    Compute conversation momentum from last 4 deltas.
+    closing = user converging (satisfied, getting what they want)
+    widening = user diverging (frustrated, not getting what they want)
+    flat = no clear trend
+    """
+    if not deltas or len(deltas) < 2:
+        return "flat"
+    recent = deltas[-4:]
+    avg_cosine = sum(d["cosine"] for d in recent) / len(recent)
+    avg_len = sum(d["len_ratio"] for d in recent) / len(recent)
+    total_frust = sum(d["frust"] for d in recent)
+    total_affirm = sum(d["affirm"] for d in recent)
+
+    if avg_cosine > 0.70 and avg_len < 1.1 and total_frust == 0:
+        return "closing"
+    if avg_cosine < 0.55 or total_frust > 1 or (avg_len > 1.3 and total_frust >= 1):
+        return "widening"
+    return "flat"
+
+
 def report_user_turn(session_id: str, user_message: str) -> None:
     """
     Classify a user follow-up message against the anchored session.
@@ -463,6 +513,20 @@ def report_user_turn(session_id: str, user_message: str) -> None:
         if session is None:
             return
 
+        # Delta tracking
+        prev_msg = session.get("last_user_message", "")
+        if prev_msg:
+            delta = _compute_delta(prev_msg, user_message)
+            deltas = session.get("deltas", [])
+            deltas.append(delta)
+            if len(deltas) > 8:
+                deltas = deltas[-8:]
+            session["deltas"] = deltas
+            session["momentum"] = _compute_momentum(deltas)
+        session["last_user_message"] = user_message
+        # Persist session with updated delta state
+        _get_session_path(session_id).write_text(json.dumps(session))
+
         api_key, tenant_id, base_url = _fb_config()
         if not api_key or not tenant_id:
             return
@@ -474,6 +538,7 @@ def report_user_turn(session_id: str, user_message: str) -> None:
             _fire_user_turn_signal(
                 base_url, api_key, tenant_id, session, session_id,
                 signal_type, confidence, dimensions, user_message,
+                momentum=session.get("momentum", "flat"),
             )
         else:
             # Fire LLM classifier in background thread
@@ -526,6 +591,7 @@ def _heuristic_classify(user_message: str) -> tuple:
 def _fire_user_turn_signal(
     base_url, api_key, tenant_id, session, session_id,
     signal_type, confidence, dimensions, raw_evidence,
+    momentum: str = "flat",
 ):
     # Drop unrelated/neutral signals — absence of reaction is not a signal
     if signal_type not in ("user_rejected", "user_accepted"):
@@ -540,6 +606,7 @@ def _fire_user_turn_signal(
         "goal": session.get("goal", ""),
         "session_id": session_id,
         "raw_evidence": raw_evidence[:500],
+        "momentum": momentum,
     }
     if dimensions:
         payload["dimensions"] = dimensions
@@ -727,3 +794,59 @@ def emit_signal(
         return r.status_code in (200, 201)
     except Exception:
         return False
+
+
+def report_session_end(session_id: str) -> None:
+    """
+    Fire a weak behavioral signal when a session ends without explicit feedback.
+
+    Uses conversation momentum (delta trajectory) to determine signal direction:
+    - closing momentum → weak positive (user probably got value and left)
+    - widening momentum → weak negative (user probably gave up)
+    - flat momentum → no signal emitted (silence without context = noise)
+
+    Always fires with low confidence (0.4) so it cannot dominate real signals.
+    Requires at least 2 deltas in session history — otherwise emits nothing.
+
+    Call this when:
+    - Session timeout detected
+    - User explicitly closes/ends the conversation
+    - Application session lifecycle ends
+    """
+    try:
+        session = _read_session(session_id)
+        if session is None:
+            return
+
+        deltas = session.get("deltas", [])
+        if len(deltas) < 2:
+            return  # not enough trajectory data — silence is just noise
+
+        mom = _compute_momentum(deltas)
+        if mom == "flat":
+            return  # no interpretable signal
+
+        # closing = user got value and left → weak positive
+        # widening = user gave up → weak negative
+        strength = 0.65 if mom == "closing" else 0.25
+        signal_type = "user_accepted" if mom == "closing" else "user_rejected"
+
+        emit_signal(
+            signal_type=signal_type,
+            strength=strength,
+            confidence=0.4,  # always low — inferred from silence, inherently uncertain
+            trace_id=session.get("trace_id", ""),
+            goal=session.get("goal", ""),
+            raw_evidence="session_end_inferred",
+        )
+
+        logger.debug(
+            "session_end_signal",
+            session_id=session_id,
+            momentum=mom,
+            signal_type=signal_type,
+            strength=strength,
+            delta_count=len(deltas),
+        )
+    except Exception as e:
+        logger.warning("report_session_end failed: %s", e)

--- a/tests/test_feedback_gate3.py
+++ b/tests/test_feedback_gate3.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from kalibr.feedback import (
-    _bag_of_words_cosine,
+    _jaccard_similarity,
     _compute_delta,
     _compute_momentum,
     report_session_end,
@@ -20,11 +20,11 @@ from kalibr.feedback import (
 class TestComputeDelta:
     def test_compute_delta_basic(self):
         delta = _compute_delta("hello world", "hello there world")
-        assert "cosine" in delta
+        assert "jaccard" in delta
         assert "len_ratio" in delta
         assert "frust" in delta
         assert "affirm" in delta
-        assert 0.0 <= delta["cosine"] <= 1.0
+        assert 0.0 <= delta["jaccard"] <= 1.0
         assert delta["len_ratio"] > 0
         assert isinstance(delta["frust"], int)
         assert isinstance(delta["affirm"], int)
@@ -42,28 +42,28 @@ class TestComputeMomentum:
     def test_compute_momentum_closing(self):
         # High cosine, short messages, no frustration, some affirmation
         deltas = [
-            {"cosine": 0.8, "len_ratio": 0.9, "frust": 0, "affirm": 1},
-            {"cosine": 0.75, "len_ratio": 1.0, "frust": 0, "affirm": 1},
-            {"cosine": 0.85, "len_ratio": 0.8, "frust": 0, "affirm": 2},
+            {"jaccard": 0.8, "len_ratio": 0.9, "frust": 0, "affirm": 1},
+            {"jaccard": 0.75, "len_ratio": 1.0, "frust": 0, "affirm": 1},
+            {"jaccard": 0.85, "len_ratio": 0.8, "frust": 0, "affirm": 2},
         ]
         assert _compute_momentum(deltas) == "closing"
 
     def test_compute_momentum_widening(self):
         # Low cosine, frustrated messages
         deltas = [
-            {"cosine": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
-            {"cosine": 0.4, "len_ratio": 1.4, "frust": 1, "affirm": 0},
+            {"jaccard": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
+            {"jaccard": 0.4, "len_ratio": 1.4, "frust": 1, "affirm": 0},
         ]
         assert _compute_momentum(deltas) == "widening"
 
     def test_compute_momentum_flat_insufficient_deltas(self):
         assert _compute_momentum([]) == "flat"
-        assert _compute_momentum([{"cosine": 0.5, "len_ratio": 1.0, "frust": 0, "affirm": 0}]) == "flat"
+        assert _compute_momentum([{"jaccard": 0.5, "len_ratio": 1.0, "frust": 0, "affirm": 0}]) == "flat"
 
     def test_compute_momentum_flat_no_clear_signal(self):
         deltas = [
-            {"cosine": 0.6, "len_ratio": 1.1, "frust": 0, "affirm": 0},
-            {"cosine": 0.65, "len_ratio": 1.0, "frust": 0, "affirm": 0},
+            {"jaccard": 0.42, "len_ratio": 1.1, "frust": 0, "affirm": 0},
+            {"jaccard": 0.45, "len_ratio": 1.0, "frust": 0, "affirm": 0},
         ]
         assert _compute_momentum(deltas) == "flat"
 
@@ -88,8 +88,8 @@ class TestReportSessionEnd:
     @patch("kalibr.feedback._get_session_path")
     def test_report_session_end_no_signal_on_flat(self, mock_path, mock_emit, tmp_path):
         path = self._write_session(tmp_path, "sess1", [
-            {"cosine": 0.6, "len_ratio": 1.0, "frust": 0, "affirm": 0},
-            {"cosine": 0.62, "len_ratio": 1.05, "frust": 0, "affirm": 0},
+            {"jaccard": 0.42, "len_ratio": 1.0, "frust": 0, "affirm": 0},
+            {"jaccard": 0.45, "len_ratio": 1.05, "frust": 0, "affirm": 0},
         ])
         mock_path.return_value = path
         report_session_end("sess1")
@@ -99,9 +99,9 @@ class TestReportSessionEnd:
     @patch("kalibr.feedback._get_session_path")
     def test_report_session_end_closing_emits_positive(self, mock_path, mock_emit, tmp_path):
         path = self._write_session(tmp_path, "sess2", [
-            {"cosine": 0.8, "len_ratio": 0.9, "frust": 0, "affirm": 1},
-            {"cosine": 0.75, "len_ratio": 1.0, "frust": 0, "affirm": 1},
-            {"cosine": 0.85, "len_ratio": 0.8, "frust": 0, "affirm": 2},
+            {"jaccard": 0.8, "len_ratio": 0.9, "frust": 0, "affirm": 1},
+            {"jaccard": 0.75, "len_ratio": 1.0, "frust": 0, "affirm": 1},
+            {"jaccard": 0.85, "len_ratio": 0.8, "frust": 0, "affirm": 2},
         ])
         mock_path.return_value = path
         report_session_end("sess2")
@@ -115,8 +115,8 @@ class TestReportSessionEnd:
     @patch("kalibr.feedback._get_session_path")
     def test_report_session_end_widening_emits_negative(self, mock_path, mock_emit, tmp_path):
         path = self._write_session(tmp_path, "sess3", [
-            {"cosine": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
-            {"cosine": 0.4, "len_ratio": 1.4, "frust": 1, "affirm": 0},
+            {"jaccard": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
+            {"jaccard": 0.4, "len_ratio": 1.4, "frust": 1, "affirm": 0},
         ])
         mock_path.return_value = path
         report_session_end("sess3")
@@ -130,7 +130,7 @@ class TestReportSessionEnd:
     @patch("kalibr.feedback._get_session_path")
     def test_report_session_end_requires_2_deltas(self, mock_path, mock_emit, tmp_path):
         path = self._write_session(tmp_path, "sess4", [
-            {"cosine": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
+            {"jaccard": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
         ])
         mock_path.return_value = path
         report_session_end("sess4")

--- a/tests/test_feedback_gate3.py
+++ b/tests/test_feedback_gate3.py
@@ -1,0 +1,137 @@
+"""Tests for Gate 3 delta tracking, momentum, and silence reward handler."""
+
+import json
+import pathlib
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from kalibr.feedback import (
+    _bag_of_words_cosine,
+    _compute_delta,
+    _compute_momentum,
+    report_session_end,
+    _read_session,
+    _get_session_path,
+)
+
+
+class TestComputeDelta:
+    def test_compute_delta_basic(self):
+        delta = _compute_delta("hello world", "hello there world")
+        assert "cosine" in delta
+        assert "len_ratio" in delta
+        assert "frust" in delta
+        assert "affirm" in delta
+        assert 0.0 <= delta["cosine"] <= 1.0
+        assert delta["len_ratio"] > 0
+        assert isinstance(delta["frust"], int)
+        assert isinstance(delta["affirm"], int)
+
+    def test_compute_delta_frustration(self):
+        delta = _compute_delta("do this", "wrong again fix this")
+        assert delta["frust"] >= 2  # "wrong", "again", "fix"
+
+    def test_compute_delta_affirmation(self):
+        delta = _compute_delta("do this", "thanks perfect great")
+        assert delta["affirm"] >= 3
+
+
+class TestComputeMomentum:
+    def test_compute_momentum_closing(self):
+        # High cosine, short messages, no frustration, some affirmation
+        deltas = [
+            {"cosine": 0.8, "len_ratio": 0.9, "frust": 0, "affirm": 1},
+            {"cosine": 0.75, "len_ratio": 1.0, "frust": 0, "affirm": 1},
+            {"cosine": 0.85, "len_ratio": 0.8, "frust": 0, "affirm": 2},
+        ]
+        assert _compute_momentum(deltas) == "closing"
+
+    def test_compute_momentum_widening(self):
+        # Low cosine, frustrated messages
+        deltas = [
+            {"cosine": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
+            {"cosine": 0.4, "len_ratio": 1.4, "frust": 1, "affirm": 0},
+        ]
+        assert _compute_momentum(deltas) == "widening"
+
+    def test_compute_momentum_flat_insufficient_deltas(self):
+        assert _compute_momentum([]) == "flat"
+        assert _compute_momentum([{"cosine": 0.5, "len_ratio": 1.0, "frust": 0, "affirm": 0}]) == "flat"
+
+    def test_compute_momentum_flat_no_clear_signal(self):
+        deltas = [
+            {"cosine": 0.6, "len_ratio": 1.1, "frust": 0, "affirm": 0},
+            {"cosine": 0.65, "len_ratio": 1.0, "frust": 0, "affirm": 0},
+        ]
+        assert _compute_momentum(deltas) == "flat"
+
+
+class TestReportSessionEnd:
+    def _write_session(self, tmp_path, session_id, deltas, momentum="flat"):
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        session_data = {
+            "trace_id": "test-trace-123",
+            "goal": "test-goal",
+            "ts": time.time(),
+            "deltas": deltas,
+            "momentum": momentum,
+            "last_user_message": "hello",
+        }
+        path = session_dir / f"{session_id}.json"
+        path.write_text(json.dumps(session_data))
+        return path
+
+    @patch("kalibr.feedback.emit_signal")
+    @patch("kalibr.feedback._get_session_path")
+    def test_report_session_end_no_signal_on_flat(self, mock_path, mock_emit, tmp_path):
+        path = self._write_session(tmp_path, "sess1", [
+            {"cosine": 0.6, "len_ratio": 1.0, "frust": 0, "affirm": 0},
+            {"cosine": 0.62, "len_ratio": 1.05, "frust": 0, "affirm": 0},
+        ])
+        mock_path.return_value = path
+        report_session_end("sess1")
+        mock_emit.assert_not_called()
+
+    @patch("kalibr.feedback.emit_signal")
+    @patch("kalibr.feedback._get_session_path")
+    def test_report_session_end_closing_emits_positive(self, mock_path, mock_emit, tmp_path):
+        path = self._write_session(tmp_path, "sess2", [
+            {"cosine": 0.8, "len_ratio": 0.9, "frust": 0, "affirm": 1},
+            {"cosine": 0.75, "len_ratio": 1.0, "frust": 0, "affirm": 1},
+            {"cosine": 0.85, "len_ratio": 0.8, "frust": 0, "affirm": 2},
+        ])
+        mock_path.return_value = path
+        report_session_end("sess2")
+        mock_emit.assert_called_once()
+        call_kwargs = mock_emit.call_args[1]
+        assert call_kwargs["signal_type"] == "user_accepted"
+        assert call_kwargs["strength"] == 0.65
+        assert call_kwargs["confidence"] == 0.4
+
+    @patch("kalibr.feedback.emit_signal")
+    @patch("kalibr.feedback._get_session_path")
+    def test_report_session_end_widening_emits_negative(self, mock_path, mock_emit, tmp_path):
+        path = self._write_session(tmp_path, "sess3", [
+            {"cosine": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
+            {"cosine": 0.4, "len_ratio": 1.4, "frust": 1, "affirm": 0},
+        ])
+        mock_path.return_value = path
+        report_session_end("sess3")
+        mock_emit.assert_called_once()
+        call_kwargs = mock_emit.call_args[1]
+        assert call_kwargs["signal_type"] == "user_rejected"
+        assert call_kwargs["strength"] == 0.25
+        assert call_kwargs["confidence"] == 0.4
+
+    @patch("kalibr.feedback.emit_signal")
+    @patch("kalibr.feedback._get_session_path")
+    def test_report_session_end_requires_2_deltas(self, mock_path, mock_emit, tmp_path):
+        path = self._write_session(tmp_path, "sess4", [
+            {"cosine": 0.3, "len_ratio": 1.5, "frust": 2, "affirm": 0},
+        ])
+        mock_path.return_value = path
+        report_session_end("sess4")
+        mock_emit.assert_not_called()


### PR DESCRIPTION
## Gate 3 — PRs 2+3: Delta Tracking + Silence Handler

**What changed:**

### Delta tracking (PR 2)
- `_compute_delta()` — bag-of-words cosine similarity + length ratio + frustration/affirmation keyword counts
- `_compute_momentum()` — rolling window of last 4 deltas → closing/widening/flat
- `report_user_turn()` now computes delta vs prior message, maintains FIFO(8) history in session file, includes momentum in signal payload
- `report_pipeline()` initializes delta state in session file

### Silence handler (PR 3)
- `report_session_end(session_id)` — fires weak signal on session end based on momentum
  - closing → strength=0.65, confidence=0.4 (weak positive)
  - widening → strength=0.25, confidence=0.4 (weak negative)
  - flat or <2 deltas → no signal emitted
- Exported from `kalibr/__init__.py`

**11 tests passing** in `tests/test_feedback_gate3.py`