### PR TITLE
docs: sync TS SDK version to v1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ pytest
 - **Python:** 3.10, 3.11, 3.12
 - **Status:** Production. Used in live agent pipelines.
 - **Latest changes (unreleased):** Tavily search provider, Nebius AI Studio support
-- **TS SDK counterpart:** `@kalibr/sdk` v1.11.7 — see [kalibr-sdk-ts](https://github.com/kalibr-ai/kalibr-sdk-ts)
+- **TS SDK counterpart:** `@kalibr/sdk` v1.12.1 — see [kalibr-sdk-ts](https://github.com/kalibr-ai/kalibr-sdk-ts)
 
 ## Contributing
 


### PR DESCRIPTION
TS SDK shipped Gate 3 parity in PR #45, now at v1.12.1. Update cross-reference in Python SDK README.