### PR TITLE
fix: kalibr_model_used on response + re-resolve tenant_id in singleton

### DIFF
--- a/kalibr/intelligence.py
+++ b/kalibr/intelligence.py
@@ -677,7 +677,7 @@ _client_lock = threading.Lock()
 
 def _get_intelligence_client() -> KalibrIntelligence:
     """Get or create the singleton intelligence client.
-    
+
     Thread-safe singleton pattern using double-checked locking.
     """
     global _intelligence_client
@@ -686,6 +686,11 @@ def _get_intelligence_client() -> KalibrIntelligence:
             # Double-check inside lock to prevent race condition
             if _intelligence_client is None:
                 _intelligence_client = KalibrIntelligence()
+    # Re-resolve if tenant_id is empty (env var may have been set after construction)
+    if not _intelligence_client.tenant_id:
+        _, tenant_id = resolve_credentials()
+        if tenant_id:
+            _intelligence_client.tenant_id = tenant_id
     return _intelligence_client
 
 

--- a/kalibr/router.py
+++ b/kalibr/router.py
@@ -894,6 +894,7 @@ class Router:
                     response.kalibr_healed = bool(heal_result.get("healed"))
                     response.kalibr_heal_count = heal_result.get("heal_count", 0)
                     response.kalibr_models_tried = heal_result.get("models_tried") or []
+                    response.kalibr_model_used = used_model
                     return response
 
                 # Heal loop exhausted all paths — fire failure telemetry.
@@ -1071,6 +1072,7 @@ class Router:
 
                     # Add trace_id to response for explicit linkage
                     response.kalibr_trace_id = trace_id
+                    response.kalibr_model_used = candidate_model
                     return response
 
                 except Exception as e:


### PR DESCRIPTION
Two bug fixes found during simulation testing:

1. **kalibr_model_used not set on response** -- completion() set kalibr_trace_id, kalibr_healed, kalibr_heal_count, kalibr_models_tried but never kalibr_model_used. Fixed at both the heal path (uses used_model) and the normal path (uses candidate_model).

2. **Singleton tenant_id empty if env var set after construction** -- _get_intelligence_client() creates the singleton once. If KALIBR_TENANT_ID was not in env at first call, tenant_id was empty string, causing 422 on every report_outcome call. Fixed: re-resolves on each call if tenant_id is empty.